### PR TITLE
Add Conduit8 - CLI registry for Claude Code skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ AI assistant by Anthropic for complex reasoning, code generation, and analysis t
 - [claudia](https://github.com/getAsterisk/claudia#readme) - Powerful GUI app and toolkit for Claude Code.
 - [claude-flow](https://github.com/ruvnet/claude-flow#readme) - AI orchestration platform with swarm intelligence and MCP tools.
 - [dotai](https://github.com/udecode/dotai#readme) - Ultimate AI development stack (Shell).
+- [Conduit8](https://github.com/conduit8/conduit8#readme) - CLI registry for discovering, installing, and managing Claude Code skills.
 
 ### Agent Collections & Orchestration
 - [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code#readme) - Curated list of commands, files, and workflows.


### PR DESCRIPTION
## Description

Adds [Conduit8](https://github.com/conduit8/conduit8) to the Frameworks & Platforms section.

## What is Conduit8?

Conduit8 is a CLI registry for discovering, installing, and managing Claude Code skills. It provides:
- Search 20+ curated skills by keyword or category
- One-command installation directly to ~/.claude/skills/
- CLI-based skill management (list, remove)

Think of it as npm/pip for Claude Code skills.

## Category

Added to: **Frameworks & Platforms**

## Installation

```bash
npx conduit8 search skills
npx conduit8 install skill <name>
```

## Website

https://conduit8.dev

## License

AGPL-3.0