### PR TITLE
Add claude-mountaineering-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ AI assistant by Anthropic for complex reasoning, code generation, and analysis t
 - [claude-code-sub-agents](https://github.com/lst97/claude-code-sub-agents#readme) - Specialized AI subagents for full-stack.
 - [awesome-claude-code-agents](https://github.com/hesreallyhim/awesome-claude-code-agents#readme) - Curated list of sub-agents.
 - [claude-code-unified-agents](https://github.com/stretchcloud/claude-code-unified-agents#readme) - Unified agent collection (Shell).
+- [claude-mountaineering-skills](https://github.com/dreamiurg/claude-mountaineering-skills#readme) - Automates mountain route research for North American peaks, aggregating data from 10+ specialized mountaineering sources into comprehensive route beta reports.
 
 ### Development & Code Tools
 - [serena](https://github.com/oraios/serena#readme) - Semantic retrieval and editing capabilities.


### PR DESCRIPTION
I built a Claude Code plugin for automating mountain route research and thought it might be useful to others.

I was spending 3-5 hours before each climb manually checking PeakBagger for peak info, SummitPost for routes, WTA for trail conditions, AllTrails for reviews, weather services, and avalanche centers. The information exists but it's scattered across a dozen sites, and it's easy to miss something important.

The plugin aggregates data from 10+ specialized mountaineering sources into a single route beta report in about 3-5 minutes. Works for any North American peak with decent documentation.

Added to Agent Collections & Orchestration section.

https://github.com/dreamiurg/claude-mountaineering-skills