### PR TITLE
Add Price Per Token to Web Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ AI assistant by Anthropic for complex reasoning, code generation, and analysis t
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) — Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) — Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🔧 Web Tools
+
+- [Price Per Token](https://pricepertoken.com) — Compare Claude API pricing with 300+ other LLM models. Includes token counter and cost calculator.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
## Summary
Adding [Price Per Token](https://pricepertoken.com) as a new Web Tools subsection under Extensions & Integrations.

## What is Price Per Token?
A free tool for comparing Claude API pricing with 300+ other LLM models.

### Features:
- Compare Claude pricing with OpenAI, Google, and 30+ other providers
- Token counter for Claude's tokenizer
- Pricing calculator for cost estimation

## Why add this?
Helps Claude users understand and compare API costs. Complements the existing Claude Usage Tracker extension.