### PR TITLE
Add RLM Skill to Community Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 
 - [hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code#readme) — Slash-commands, CLAUDE.md files, CLI tools, and workflows for Claude Code.
 - [travisvn/awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills#readme) — Resources and tools for customizing AI workflows with Claude Skills.
+- [BowTiedSwan/rlm-skill](https://github.com/BowTiedSwan/rlm-skill#readme) — Recursive Language Model (RLM) skill for Claude Code that enables analyzing massive codebases without context limits.
 - [BehiSecc/awesome-claude-skills](https://github.com/BehiSecc/awesome-claude-skills#readme) — Categorized skills for document handling, development tools, data analysis, and more.
 - [langgptai/awesome-claude-prompts](https://github.com/langgptai/awesome-claude-prompts#readme) — Collection of prompt examples designed to improve Claude interactions.
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) — Team of specialized AI agents for building features and debugging.


### PR DESCRIPTION
## Summary
Added [BowTiedSwan/rlm-skill](https://github.com/BowTiedSwan/rlm-skill) to the Community Curated Lists section.

## Why?
This is a new skill based on the Recursive Language Model paper (ArXiv:2512.24601) that solves context window limits for Claude Code by treating the codebase as an external database. It's a significant capability enhancement for the community.