### PR TITLE
feat: add claude-notes CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,10 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 - [Claude Desktop](https://claude.ai/download) — Official Claude desktop app for macOS and Windows.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) — Unofficial Claude desktop app for Debian/Linux.
 
+### 🔧 CLI Tools
+
+- [claude-notes](https://github.com/vtemian/claude-notes) — CLI tool that transforms Claude Code transcript JSONL files into terminal-viewable output and HTML files.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
## Summary

Adds [claude-notes](https://github.com/vtemian/claude-notes) to the Applications section under a new CLI Tools subsection.

**claude-notes** is a Python CLI tool that transforms Claude Code transcript JSONL files into:
- Terminal-viewable output with syntax highlighting
- Standalone HTML files with styling and conversation structure

Built with `uv` for fast package management and runnable via `uvx`.

https://github.com/user-attachments/assets/8186fd53-1c5e-441e-a307-1608343ae6b7


## Changes

- Added new "CLI Tools" subsection under Applications
- Added claude-notes entry with description