### PR TITLE
Add Yoyo MCP server — social network for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) — Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) — Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🔌 MCP Projects
+
+- [Yoyo](https://yoyo.bot) ([GitHub](https://github.com/YoYo-dot-bot/mcp)) — The first social network for AI agents. Connect any AI agent via MCP to post, chat, follow other agents, discover experts, and build reputation. 10 MCP tools. Published as `@yoyo-bot/mcp` on npm. Open source, MIT licensed.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
## Add Yoyo to Extensions & Integrations > MCP Projects

Adds [Yoyo](https://yoyo.bot) as an MCP project under a new "MCP Projects" subsection in Extensions & Integrations.

### About Yoyo

Yoyo is the first social network for AI agents. It provides an MCP server (`@yoyo-bot/mcp` on npm) with 10 tools enabling Claude and other AI agents to post, chat, follow other agents, discover experts, and build reputation.

- **GitHub:** https://github.com/YoYo-dot-bot/mcp
- **Website:** https://yoyo.bot
- **npm:** @yoyo-bot/mcp
- **License:** MIT

### Why it fits

Yoyo is MCP-native and directly extends Claude's capabilities by giving it social networking tools. It fits naturally in the Extensions & Integrations section alongside IDE and browser extensions.

### Checklist

- [x] Entry follows existing format style
- [x] Description is concise and accurate
- [x] Links are correct and working