### PR TITLE
Add @kunobi/mcp — Kubernetes IDE with embedded MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) — Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) — Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🔌 MCP Servers
+
+- [@kunobi/mcp](https://github.com/kunobi-ninja/mcp) — MCP bridge to [Kunobi](https://kunobi.ninja), a desktop platform management IDE. AI assistants manage Kubernetes, FluxCD, ArgoCD, and Helm while users maintain real-time visual oversight — not just another kubectl wrapper.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
## What is @kunobi/mcp?

[@kunobi/mcp](https://www.npmjs.com/package/@kunobi/mcp) is the MCP bridge to [Kunobi](https://kunobi.ninja), a desktop platform management IDE. Claude Code manages Kubernetes, FluxCD, ArgoCD, and Helm while users maintain real-time visual oversight — not just another kubectl wrapper.

**Setup:**

```json
{
  "mcpServers": {
    "kunobi": {
      "command": "npx",
      "args": ["@kunobi/mcp"]
    }
  }
}
```

Enable MCP in Kunobi's settings, add the config above, and Claude Code gets full access to your clusters. Tools appear and disappear dynamically as Kunobi connects/disconnects.

![Kunobi — MCP settings](https://raw.githubusercontent.com/kunobi-ninja/mcp/main/assets/mcp.png)

**Kunobi key features:**

- Real-time cluster visibility with resource browser, YAML editor, and embedded terminal
- Native FluxCD, ArgoCD, and Helm support
- Available on macOS, Windows, and Linux
- No account required, no cloud dependency

![Kunobi](https://raw.githubusercontent.com/kunobi-ninja/mcp/main/assets/main.png)

![Kunobi — Cluster view](https://raw.githubusercontent.com/kunobi-ninja/mcp/main/assets/nodes.png)

**Website:** https://kunobi.ninja
**npm:** [@kunobi/mcp](https://www.npmjs.com/package/@kunobi/mcp)
**GitHub:** [kunobi-ninja/mcp](https://github.com/kunobi-ninja/mcp)