### PR TITLE
Add OpenClaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 
 ### 🤖 Self-Hosted
 
-- [OpenClaw](https://github.com/openclaw/openclaw) — Self-hosted AI assistant that connects Claude to WhatsApp, Telegram, Discord, Slack, iMessage, SMS, Email, and Signal from a single deployment.
+- [OpenClaw](https://github.com/openclaw/openclaw) — Self-hosted AI assistant that connects Claude to WhatsApp, Telegram, Discord, Slack, iMessage, SMS, Email, and Signal from a single deployment. ([Setup Guide](https://clawdbot.blog/getting-started/installation/))
 
 ---
 


### PR DESCRIPTION
Adding [OpenClaw](https://github.com/openclaw/openclaw) under a new "Self-Hosted" subcategory in the Applications section.

OpenClaw is a self-hosted AI assistant that connects Claude to eight messaging channels (WhatsApp, Telegram, Discord, Slack, iMessage, SMS, Email, Signal) from a single deployment. It supports macOS, Linux, Windows, and Docker.

- **GitHub**: https://github.com/openclaw/openclaw (190k+ stars)
- **Setup Guide**: https://clawdbot.blog/getting-started/installation/
- **License**: MIT
- **Language**: TypeScript