### PR TITLE
Add Claude Code Ultimate Guide to Community Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 - [40+ Claude Code Tips](https://github.com/ykdojo/claude-code-tips#readme) — Tips for getting the most out of Claude Code, including a custom status line script, cutting the system prompt in half, using Gemini CLI as Claude Code's minion, and Claude Code running itself in a container. Also includes the dx plugin for GitHub Actions debugging, conversation cloning, and handoffs.
 - [My Experience With Claude Code After 2 Weeks of Adventures](https://sankalp.bearblog.dev/my-claude-code-experience-after-2-weeks-of-usage/) - Part 1: Real-world lessons on using a `TODO.md` file to keep Claude on track, managing costs, and why it often outperforms Cursor for complex refactors.
 - [A Guide to Claude Code 2.0 and getting better at using coding agents](https://sankalp.bearblog.dev/my-experience-with-claude-code-20-and-how-to-get-better-at-using-coding-agents/#setup) - Part 2: A deep dive into the 2.0 update, focusing on the "Agent Manager" mindset, context engineering, and using sub-agents for larger codebases.
+- [Claude Code Ultimate Guide](https://github.com/FlorianBruniaux/claude-code-ultimate-guide#readme) — Covers Claude Code from beginner to power user with production-ready templates, agentic workflow guides, quizzes, and a cheatsheet. A valuable community resource for learning Claude Code in depth.
 
 ---
 


### PR DESCRIPTION
## Addition

Adding [Claude Code Ultimate Guide](https://github.com/FlorianBruniaux/claude-code-ultimate-guide#readme) to the **Educational Resources > Community Guides** section.

## About the resource

A tremendous feat of documentation, this guide covers Claude Code from beginner to power user, with production-ready templates for Claude Code features (hooks, agents, skills, commands), guides on agentic workflows, and a lot of great learning materials, including quizzes and a handy "cheatsheet".

**Stats:** 137 stars | 10 forks | 19,500+ line guide | 127 production-ready templates | 17 categories

Whether it's the "ultimate" guide to Claude Code will be up to the reader, but a valuable resource nonetheless (as with all documentation sites, make sure it's up to date before you bet the farm).