### PR TITLE
Add Digital Samba Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 - [Claude Code Theme](https://github.com/ashwingopalsamy/claude-code-theme) — Claude-inspired VS Code theme pack with dark/light/high-contrast and brand variants, semantic token tuning, and ANSI-optimized terminal colors.
 - [Claude VSCode Theme](https://marketplace.visualstudio.com/items?itemName=AlvinUnreal.claude-vscode-theme) — Thoughtful dark theme collection with classic and italic variants. Inspired by Claude AI with carefully balanced contrast and warm syntax colors.
 
+### 🔧 Claude Code Skills
+
+- [Digital Samba Skill](https://github.com/digitalsamba/digital-samba-skill) — Claude Code skill for building video conferencing integrations with Digital Samba. Provides API reference, SDK methods, integration patterns, and JWT token guides.
+
 ### 🌐 Browser Extensions
 
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) — Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.


### PR DESCRIPTION
## Add Digital Samba Skill to Extensions & Integrations

Adds [Digital Samba Skill](https://github.com/digitalsamba/digital-samba-skill) under a new **Claude Code Skills** subsection within Extensions & Integrations.

### Why this project deserves inclusion

- **Open source** with an active public repository
- **Actively maintained** — regular commits with documented releases
- **Well-documented** — comprehensive API reference, SDK methods, integration patterns, and JWT token guides
- **Useful for the Claude community** — the first Claude Code skill for video conferencing, helping developers embed Digital Samba video calls into their applications using Claude Code

### Entry format

```
- [Digital Samba Skill](https://github.com/digitalsamba/digital-samba-skill) — Claude Code skill for building video conferencing integrations with Digital Samba. Provides API reference, SDK methods, integration patterns, and JWT token guides.
```

I also introduced a new `### 🔧 Claude Code Skills` subsection under Extensions & Integrations. Claude Code skills are an emerging category that could grow as more developers create them, so having a dedicated subsection seems appropriate.