### PR TITLE
Add B12 Website Generator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) — Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) — Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🔧 Claude Code Skills
+
+- [B12 Website Generator](https://github.com/b12io/b12-claude-plugin) - Claude Code skill for generating professional, production-ready websites from a simple business name and description.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
Adds [b12-website-generator](https://github.com/b12io/b12-claude-plugin) — a skill that generates a professional website from a business name and description.

The skill gathers the business name and description from the user, then produces a pre-populated signup link for an instant B12 site draft. 

Website: https://www.b12.io/