### PR TITLE
Add Mantra - AI coding session time machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 
 - [Claude Desktop](https://claude.ai/download) — Official Claude desktop app for macOS and Windows.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) — Unofficial Claude desktop app for Debian/Linux.
+- [Mantra](https://mantra.gonewx.com) — Time machine for AI coding sessions. Automatically captures, browses, searches, and restores sessions for Claude Code, Cursor, Windsurf, Copilot, and Aider. Desktop app with CLI support for macOS, Linux, and Windows.
 
 ---
 


### PR DESCRIPTION
## What is Mantra?

[Mantra](https://mantra.gonewx.com) is a time machine for AI coding sessions. It automatically captures, browses, searches, and restores sessions for Claude Code, Cursor, Gemini CLI, Codex, Copilot, and Aider (Windsurf: In Development).

## Why it belongs here

Mantra is a desktop application that enhances the Claude Code experience by preserving and managing coding session history. Added to the **Applications > Desktop** section as a companion tool for Claude Code users.

- Desktop app (macOS, Linux, Windows) with CLI support
- Website: https://mantra.gonewx.com
- Public releases: https://github.com/mantra-hq/mantra-releases