### PR TITLE
Add claude-code-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 - [Claude Desktop](https://claude.ai/download) — Official Claude desktop app for macOS and Windows.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) — Unofficial Claude desktop app for Debian/Linux.
 
+
+### 🌐 Web / Self-Hosted
+
+- [claude-code-web](https://github.com/exitxio/claude-code-web) — Self-hosted server that exposes Claude Code agent as an HTTP endpoint. No API key — runs on your existing Claude subscription. Docker one-liner deploy.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
Adds [claude-code-web](https://github.com/exitxio/claude-code-web) to the **Applications** section under a new **Web / Self-Hosted** subsection.

claude-code-web is a self-hosted server that exposes the Claude Code agent as an HTTP endpoint. It requires no API key and runs on your existing Claude subscription. Deploys with a single Docker command.