### PR TITLE
Add Claude Code Open to Applications > Web section

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 - [Claude Desktop](https://claude.ai/download) — Official Claude desktop app for macOS and Windows.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) — Unofficial Claude desktop app for Debian/Linux.
 
+### 🌐 Web
+
+- [Claude Code Open](https://github.com/kill136/claude-code-open#readme) — Open-source AI coding platform with browser-based Web IDE (Monaco editor, file tree, AI-enhanced editing), Blueprint multi-agent system, 37+ built-in tools, scheduled task daemon, self-evolution, one-click installers, and MCP protocol support. MIT licensed.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
## Summary

Adds [Claude Code Open](https://github.com/kill136/claude-code-open) to the Applications section under a new "Web" sub-category.

Claude Code Open is an open-source AI coding platform (MIT licensed) featuring:

- **Web IDE** — Browser-based IDE with Monaco editor, file tree, and AI-enhanced editing
- **Blueprint Multi-Agent System** — Smart Planner + Lead Agent + Autonomous Workers for complex task decomposition
- **37+ Built-in Tools** — File ops, database client (PG/MySQL/SQLite/Redis/MongoDB), browser automation, DAP debugger, LSP, scheduled tasks
- **Self-Evolution** — AI can modify its own source code with TypeScript compilation checks and hot-reload
- **One-Click Install** — Automated installers for Windows/macOS/Linux
- **MCP Protocol** — Full Model Context Protocol support with auto-discovery

GitHub: https://github.com/kill136/claude-code-open
Live Demo: http://voicegpt.site:3456/