### PR TITLE
Add changelog-gen: AI-powered changelog generator using Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 
 ### 🔧 SDKs & Development Tools
 
+- [changelog-gen](https://github.com/indoor47/changelog-gen) - AI-powered changelog generator that converts git commits into human-readable release notes using Claude
 **Official SDKs** — The most reliable way to use the Claude API. All support messages, tool use, streaming, prompt caching, and more.
 
 - [anthropic-sdk-python](https://github.com/anthropics/anthropic-sdk-python) — Python SDK with async support, type hints, and full feature parity.


### PR DESCRIPTION
Adds **changelog-gen** — AI-powered changelog generator that converts git commits into human-readable release notes using Claude.

Repo: https://github.com/indoor47/changelog-gen

```bash
python changelog_gen.py --repo . --since v1.2.0 --out CHANGELOG.md
```

MIT license, open source.