### PR TITLE
Add ClawWP — WordPress plugin powered by Claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 - [Claude Desktop](https://claude.ai/download) — Official Claude desktop app for macOS and Windows.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) — Unofficial Claude desktop app for Debian/Linux.
 
+### 🌐 Web
+
+- [ClawWP](https://github.com/hifriendbot/clawwp) — WordPress plugin that lets Claude manage your site through conversation using native tool use. Supports content creation, plugin management, site settings, and more. Open source, GPLv2.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
## Add ClawWP to Applications > Web

[ClawWP](https://github.com/hifriendbot/clawwp) is an open-source WordPress plugin that uses Claude's native tool use (function calling) to manage WordPress sites through natural conversation.

### Why it belongs here

- **Built specifically for Claude** — uses Claude as its primary Ai provider (Sonnet 4.5, Opus 4, Haiku 3.5) with native tool use / function calling
- **Open source** — GPLv2 licensed, public repo with documentation
- **Actively maintained** — regular commits, active development
- **Meaningful functionality** — content creation, plugin management, site settings, media handling, and more through conversational Ai
- **Free tier** available via [hifriendbot.com/clawwp](https://hifriendbot.com/clawwp/)

### Placement

Added under **Applications > Web** (new subsection), following the existing Desktop subsection pattern.

### Format

Follows the contributing guidelines: `- [Name](URL) — Description.`