### PR TITLE
Add doc2md and orchestration-protocol to Claude Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 - [Claude Code Theme](https://github.com/ashwingopalsamy/claude-code-theme) — Claude-inspired VS Code theme pack with dark/light/high-contrast and brand variants, semantic token tuning, and ANSI-optimized terminal colors.
 - [Claude VSCode Theme](https://marketplace.visualstudio.com/items?itemName=AlvinUnreal.claude-vscode-theme) — Thoughtful dark theme collection with classic and italic variants. Inspired by Claude AI with carefully balanced contrast and warm syntax colors.
 
+### 🔧 Claude Code Tools
+
+- [doc2md](https://github.com/orangefineblue/doc2md) — High-fidelity PDF/DOCX/PPTX to Markdown conversion pipeline with multi-stage QC, image extraction, and Claude Code integration. Solves Anthropic's copyright filter blocking PDF reads.
+- [claude-code-orchestration-protocol](https://github.com/orangefineblue/claude-code-orchestration-protocol) — Zero-read orchestrator protocol that turns Claude Code into a pure agent router with QC loops, progressive documentation, and handover architecture for complex multi-step workflows.
+
 ### 🌐 Browser Extensions
 
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) — Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.


### PR DESCRIPTION
## Summary

Adding two open-source Claude Code community tools to the Extensions & Integrations section:

### doc2md
- **Repository**: https://github.com/orangefineblue/doc2md
- **License**: MIT
- **What it does**: High-fidelity PDF/DOCX/PPTX to Markdown conversion pipeline. Solves the problem of Anthropic's copyright filter blocking PDF reads in Claude Code. Features multi-extractor support, per-image classification, multi-stage QC, and Claude Code integration (PreToolUse hook + skill).
- **Size**: ~15,000 lines of Python

### claude-code-orchestration-protocol
- **Repository**: https://github.com/orangefineblue/claude-code-orchestration-protocol
- **License**: MIT
- **What it does**: Zero-read orchestrator protocol for Claude Code. Turns the main session into a pure agent router that never reads source files, preventing context rot. Features QC loops, progressive documentation, handover architecture, and anti-polling protocol.

Both tools are designed specifically for Claude Code workflows and complement the existing resources in the list.