### PR TITLE
Add Presentation Chef skill to Extensions & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 - [Claude Code Theme](https://github.com/ashwingopalsamy/claude-code-theme) — Claude-inspired VS Code theme pack with dark/light/high-contrast and brand variants, semantic token tuning, and ANSI-optimized terminal colors.
 - [Claude VSCode Theme](https://marketplace.visualstudio.com/items?itemName=AlvinUnreal.claude-vscode-theme) — Thoughtful dark theme collection with classic and italic variants. Inspired by Claude AI with carefully balanced contrast and warm syntax colors.
 
+### 🛠️ Skills
+
+- [Presentation Chef](https://github.com/sacredvoid/presentation-chef) — Converts any content into cinematic Apple Keynote-style HTML presentations with 5 themes, 13 slide types, speaker notes, and PDF export as a single self-contained `.html` file.
+
 ### 🌐 Browser Extensions
 
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) — Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.


### PR DESCRIPTION
Adds **[Presentation Chef](https://github.com/sacredvoid/presentation-chef)** under a new Skills subsection in Extensions & Integrations.

Presentation Chef converts any content into cinematic Apple Keynote-style HTML presentations as a single self-contained `.html` file with zero dependencies. Features 5 theme presets, 13 slide types, speaker notes sidebar, and PDF export.

Added a `### Skills` subsection between IDE Extensions and Browser Extensions since this is a Claude Code skill (not an IDE extension or browser extension).