### PR TITLE
Add ai-marketing-claude-code-skills — 19 free marketing skills for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) — Team of specialized AI agents for building features and debugging.
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) — 100+ specialized AI agents for full-stack development maintained by the community.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) — Curated list of Model Context Protocol (MCP) servers for extending Claude's capabilities.
+- [BrianRWagner/ai-marketing-claude-code-skills](https://github.com/BrianRWagner/ai-marketing-claude-code-skills) — 19 free Claude Code skills for marketing: AI discoverability, content, SEO, LinkedIn, cold outreach, and more.
 
 ---
 


### PR DESCRIPTION
## What this adds

Adds [BrianRWagner/ai-marketing-claude-code-skills](https://github.com/BrianRWagner/ai-marketing-claude-code-skills) to the **Community Curated Lists** section.

19 free Claude Code skills covering a domain not currently represented: **marketing and growth**.

### Skills included
`ai-discoverability-audit`, `case-study-builder`, `cold-outreach-sequence`, `content-idea-generator`, `de-ai-ify`, `go-mode`, `homepage-audit`, `last30days`, `linkedin-authority-builder`, `linkedin-profile-optimizer`, `marketing-principles`, `newsletter-creation-curation`, `plan-my-day`, `positioning-basics`, `reddit-insights`, `social-card-gen`, `testimonial-collector`, `voice-extractor`, `youtube-summarizer`

### Why it fits here
Marketing/growth is not represented in the current Community Curated Lists. This fills that gap for founders, marketers, and solo builders using Claude Code.