### PR TITLE
Add DiscoClaw to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 - [Claude Desktop](https://claude.ai/download) — Official Claude desktop app for macOS and Windows.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) — Unofficial Claude desktop app for Debian/Linux.
 
+### 💬 Chat Integrations
+
+- [DiscoClaw](https://github.com/DiscoClaw/discoclaw) — Personal AI orchestrator that turns Discord into a persistent workspace for Claude Code, with durable memory, task tracking, and cron-based automation.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
## Summary

- Adds [DiscoClaw](https://github.com/DiscoClaw/discoclaw) under **Applications > Chat Integrations** (new subsection)
- DiscoClaw is a personal AI orchestrator that turns Discord into a persistent workspace for Claude Code — with durable memory across sessions, task tracking, and cron-based automation
- MIT licensed