### PR TITLE
Add OpenPaw (pawmode) to CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### ⌨️ CLI Tools
+
+- [OpenPaw](https://github.com/daxaur/openpaw) -  Open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 built-in skills including Telegram, Discord, Obsidian memory, daily briefings, and more. No daemon, no cloud, MIT licensed.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
## Summary
- Adds [OpenPaw](https://github.com/daxaur/openpaw) to a new CLI Tools subsection under Applications
- OpenPaw is an open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — no daemon, no cloud, MIT licensed

## Details
- **npm**: https://www.npmjs.com/package/pawmode
- **License**: MIT
- **Install**: `npx pawmode`