### PR TITLE
Add iSCALE Claude Code tools to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,13 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### 🤖 Claude Code Tools
+
+- [Agentic React Template](https://github.com/iscale-llc/agentic-react-nextjs-shadcn) -  Agent-testable SaaS starter with Next.js 16, shadcn/ui, and Tailwind CSS. Accessibility-first components optimized for AI agent testing.
+- [Domain Finder](https://github.com/iscale-llc/domain-finder-claude-code) -  Domain brainstorming powered by Claude Code. Generates creative domain name ideas and checks availability via the Namecheap API.
+- [Everflow Offer Sync](https://github.com/iscale-llc/claude-code-everflow-sync) -  Affiliate offer sync via Claude Code. Pulls offers from Everflow, diffs against local state, and applies changes with AI-driven field mapping.
+- [Facebook Ad Builder](https://github.com/iscale-llc/iscale-facebook-ad-builder) -  AI-powered Facebook ad automation. Scrapes competitor ads, generates creative with Claude, and pushes campaigns to the Facebook Ads API.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
## Summary
Adds a new "Claude Code Tools" subsection under Applications with 4 open-source tools:

- **[Agentic React Template](https://github.com/iscale-llc/agentic-react-nextjs-shadcn)** - Agent-testable SaaS starter (Next.js 16 + shadcn/ui)
- **[Domain Finder](https://github.com/iscale-llc/domain-finder-claude-code)** - Domain brainstorming with Claude Code + Namecheap API
- **[Everflow Offer Sync](https://github.com/iscale-llc/claude-code-everflow-sync)** - Affiliate offer sync powered by Claude Code
- **[Facebook Ad Builder](https://github.com/iscale-llc/iscale-facebook-ad-builder)** - AI ad automation: scrape, generate, push to Facebook Ads API