### PR TITLE
Add dna-claude-analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### 🧬 Data & Analysis
+
+- [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis#readme) -  Personal genome analysis toolkit built with Claude Code. Analyzes raw DNA data across 17 categories (health risks, ancestry, nutrition, pharmacogenomics, and more) and generates a terminal-style HTML dashboard.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
Added [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to Applications > Data & Analysis.

Personal genome analysis toolkit that analyzes raw DNA data across 17 categories and generates a terminal-style HTML dashboard. Built entirely with Claude Code.