### PR TITLE
Add OpenPaw to CLI Tools & Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### ⚡ CLI Tools & Frameworks
+
+- [OpenPaw](https://github.com/daxaur/openpaw) -  Open-source personal assistant wizard for Claude Code. Adds reusable skills, scheduling, dashboard tasks, Telegram control, focus mode, and optional Paw-themed Claude Code customization. Install with `npx pawmode`.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
Adds [OpenPaw](https://github.com/daxaur/openpaw) under a new **CLI Tools & Frameworks** subsection in **Extensions & Integrations**.

OpenPaw is an open-source personal assistant wizard for Claude Code with reusable skills, scheduling, dashboard tasks, Telegram control, focus mode, and optional Paw-themed Claude Code customization. Install with `npx pawmode`.

The diff was rewritten to keep this PR scoped to the OpenPaw addition only.