### PR TITLE
Add debug-skill: interactive debugger for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🎯 Claude Skills
+
+- **[AlmogBaku/debug-skill](https://github.com/AlmogBaku/debug-skill)** -  Give your AI agent a real debugger — breakpoints, stepping, variable inspection, and stack traces via the `dap` CLI. Supports Python, Go, Node.js/TypeScript, Rust, and C/C++.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
## What is this?

[`debugging-code`](https://github.com/AlmogBaku/debug-skill) is a skill that gives AI agents access to a real interactive debugger via the `dap` CLI.

Instead of print-statement debugging, the agent can:
- Set breakpoints and step through code line by line
- Inspect live variable values and the call stack
- Evaluate expressions against the running process

**Supported languages:** Python · Go · Node.js/TypeScript · Rust · C/C++

**GitHub:** https://github.com/AlmogBaku/debug-skill