### PR TITLE
Add BurnRate - AI coding cost analytics CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Code Theme](https://github.com/ashwingopalsamy/claude-code-theme) -  Claude-inspired VS Code theme pack with dark/light/high-contrast and brand variants, semantic token tuning, and ANSI-optimized terminal colors.
 - [Claude VSCode Theme](https://marketplace.visualstudio.com/items?itemName=AlvinUnreal.claude-vscode-theme) -  Thoughtful dark theme collection with classic and italic variants. Inspired by Claude AI with carefully balanced contrast and warm syntax colors.
 
+### 🔧 CLI Tools
+
+- [BurnRate](https://github.com/burnrate-dev/burnrate) - Multi-provider AI coding cost analytics CLI. Tracks token usage, costs, and optimization opportunities across Claude Code, Cursor, Copilot, Windsurf, Aider, Cline, and Codex with a local dashboard.
+
 ### 🌐 Browser Extensions
 
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.


### PR DESCRIPTION
## What is BurnRate?

[BurnRate](https://getburnrate.io) is a local-first CLI tool that tracks AI coding tool usage and costs across 7 providers: Claude Code, Cursor, GitHub Copilot, Windsurf, Aider, Cline, and OpenAI Codex.

**Key features:**
- Real-time cost analytics dashboard
- 46 optimization rules to reduce spending
- Rate limit monitoring
- Team budgets and alerts
- PDF report generation
- Written in Go, single binary, no dependencies

GitHub: https://github.com/burnrate-dev/burnrate

Added under **Extensions & Integrations > CLI Tools** as it complements the existing Claude Usage Tracker browser extension with a terminal-based, multi-provider alternative.