### PR TITLE
Add Xquik MCP resource and repair project metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
-- [Xquik x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) -  X/Twitter data platform — MCP server, REST API, 20 extraction tools, AI agent skill.
+- [Xquik x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) -  X/Twitter automation with MCP server, REST API (121 endpoints), 23 extraction tools, and AI agent skill.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [Xquik x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) -  X/Twitter data platform — MCP server, REST API, 20 extraction tools, AI agent skill.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [Xquik X/Twitter Scraper](https://github.com/Xquik-dev/x-twitter-scraper#readme) -  Hosted proprietary X/Twitter data extraction MCP server with [remote discovery metadata](https://xquik.com/.well-known/mcp.json), REST API, webhooks, and SDKs; OAuth 2.1 or API key. Not affiliated with X Corp.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alvinunreal/awesome-claude.git"
+    "url": "git+https://github.com/webfuse-com/awesome-claude.git"
   },
   "keywords": [
     "awesome",
@@ -26,9 +26,9 @@
   "author": "Alvin Unreal",
   "license": "CC0-1.0",
   "bugs": {
-    "url": "https://github.com/alvinunreal/awesome-claude/issues"
+    "url": "https://github.com/webfuse-com/awesome-claude/issues"
   },
-  "homepage": "https://github.com/alvinunreal/awesome-claude#readme",
+  "homepage": "https://awesomeclaude.ai",
   "devDependencies": {
     "awesome-lint": "^0.18.0",
     "markdown-link-check": "^3.12.2"


### PR DESCRIPTION
## Summary

- Add Xquik X/Twitter Scraper to the MCP resources section.
- Link the public source repository and remote MCP discovery metadata.
- Describe the hosted proprietary service and OAuth 2.1 or API-key authentication accurately.
- Include the independent X Corp affiliation notice.
- Rebuild on current `main` as exactly 1 SSH-signed commit.

## Independent repository fix

The package metadata still pointed repository tools and bug reports to the former `alvinunreal/awesome-claude` location and used its old GitHub README as the homepage. This PR updates the repository and issue URLs to `webfuse-com/awesome-claude`, sets the canonical `awesomeclaude.ai` homepage, and restores the missing final newline.

## Validation

- `npm ci` completed successfully.
- Package repository, issue, homepage, and final-newline assertions pass.
- The Xquik repository, discovery metadata, project issue tracker, and homepage return HTTP 200.
- `git diff --check` passes.
- GitHub verifies the 1 public commit's SSH signature.
- `awesome-lint` reports the same 38 existing list-wide findings; none point to the Xquik entry.

Disclosure: I am affiliated with Xquik.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
