### PR TITLE
Add BGPT MCP to Model Context Protocol section

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) -  Hosted MCP server for searching scientific papers with full-text experimental data. 50 free searches, no API key needed.
 
 ---
 


### PR DESCRIPTION
Adds [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) — hosted MCP server for searching scientific papers with full-text experimental data.

- SSE + Streamable HTTP endpoints
- Tool: `search_papers`
- 50 free searches, no API key needed