### PR TITLE
Add bitcoin-mcp - First Bitcoin MCP server on Anthropic Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [bitcoin-mcp](https://github.com/Bortlesboat/bitcoin-mcp) -  Bitcoin fee intelligence and blockchain analysis MCP server. 49 tools, zero-config. First Bitcoin MCP on Anthropic Registry.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [bitcoin-mcp](https://github.com/Bortlesboat/bitcoin-mcp) to the MCP servers section.

- **49 tools** for Bitcoin fee intelligence, blockchain analysis, mempool monitoring, PSBT security, and more
- **Zero-config** — auto-falls back to public API when no local Bitcoin node is available
- **MIT licensed**, PyPI installable (`pip install bitcoin-mcp`)
- **First Bitcoin MCP server on the Anthropic MCP Registry** ([registry link](https://mcp.anthropic.com/server/bitcoin-mcp))
- 116 tests, 6 prompts, 7 resources