### PR TITLE
Add awesome-web-agents to Community Curated Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [langgptai/awesome-claude-prompts](https://github.com/langgptai/awesome-claude-prompts#readme) -  Collection of prompt examples designed to improve Claude interactions.
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) -  Team of specialized AI agents for building features and debugging.
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) -  100+ specialized AI agents for full-stack development maintained by the community.
+- [steel-dev/awesome-web-agents](https://github.com/steel-dev/awesome-web-agents#readme) -  Curated list of web-browsing agents and browser automation tooling, including Steel Browser, the AI-native CLI, and the reusable `steel-browser` skill.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated list of Model Context Protocol (MCP) servers for extending Claude's capabilities.
 
 ---


### PR DESCRIPTION
This adds `steel-dev/awesome-web-agents` to the community-curated lists section.

It fits here because it gives Claude users a maintained map of browser-native agent tooling and workflows, including Steel Browser, the AI-native CLI, and the reusable `steel-browser` skill.

Links:
- List: https://github.com/steel-dev/awesome-web-agents
- Browser repo: https://github.com/steel-dev/steel-browser
- CLI: https://github.com/steel-dev/cli
- Skill: https://github.com/steel-dev/cli/tree/main/skills/steel-browser
- Docs: https://docs.steel.dev/
- Blog: https://steel.dev/blog/introducing-steel-cli-v0-2-0-browser-automation-built-for-agents

Example use case: use the AI-native CLI or skill to run a browser workflow against a JS-heavy app, extract content, and save screenshot or PDF artifacts.