### PR TITLE
Add TechWolf AI-First Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Code Theme](https://github.com/ashwingopalsamy/claude-code-theme) -  Claude-inspired VS Code theme pack with dark/light/high-contrast and brand variants, semantic token tuning, and ANSI-optimized terminal colors.
 - [Claude VSCode Theme](https://marketplace.visualstudio.com/items?itemName=AlvinUnreal.claude-vscode-theme) -  Thoughtful dark theme collection with classic and italic variants. Inspired by Claude AI with carefully balanced contrast and warm syntax colors.
 
+### 🧰 Skills & Toolkits
+
+- [AI-First Toolkit](https://github.com/techwolf-ai/ai-first-toolkit#readme) - Open-source Claude Code skills for AI-first engineering. Audit, re-engineer, or bootstrap projects against design principles and patterns, plus a content studio for thought leadership.
+
 ### 🌐 Browser Extensions
 
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.


### PR DESCRIPTION
## Summary

- Adds [AI-First Toolkit](https://github.com/techwolf-ai/ai-first-toolkit) to the Extensions & Integrations section under a new "Skills & Toolkits" subsection.
- Open-source Claude Code skills for AI-first engineering: audit, re-engineer, or bootstrap projects against design principles and patterns, plus a content studio for thought leadership.