### PR TITLE
Add Untether — Telegram bridge for Claude Code and other AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 📱 Remote Access
+
+- **[Untether](https://github.com/littlebearapps/untether)** - Telegram bridge for AI coding agents including Claude Code. Remote task management, interactive permissions, voice input, cost tracking. Supports 6 engines
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
Adds [Untether](https://github.com/littlebearapps/untether) to the Extensions & Integrations section under a new "Remote Access" subsection.

Untether bridges AI coding agents to Telegram for remote task management. Send tasks by voice or text, stream progress in real time, and approve tool calls with inline buttons — from your phone.

Supports 6 engines: Claude Code, Codex, OpenCode, Pi, Gemini CLI, Amp.

Features: interactive permissions, plan mode, cost tracking, voice transcription, multi-project support, session resume.

MIT licensed, Python 3.12+: `uv tool install untether`