### PR TITLE
Add onWatch CLI to Extensions & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Code Theme](https://github.com/ashwingopalsamy/claude-code-theme) -  Claude-inspired VS Code theme pack with dark/light/high-contrast and brand variants, semantic token tuning, and ANSI-optimized terminal colors.
 - [Claude VSCode Theme](https://marketplace.visualstudio.com/items?itemName=AlvinUnreal.claude-vscode-theme) -  Thoughtful dark theme collection with classic and italic variants. Inspired by Claude AI with carefully balanced contrast and warm syntax colors.
 
+### ⌨️ CLI Tools
+
+- [onWatch](https://github.com/onllm-dev/onwatch) -  Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, and more). Background daemon, ~15MB binary, <50MB RAM, zero telemetry. Works with Claude Code, Cline, Roo Code, and Kilo Code. Includes a Material Design 3 web dashboard.
+
 ### 🌐 Browser Extensions
 
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.


### PR DESCRIPTION
## Summary

- Adds [onWatch](https://github.com/onllm-dev/onwatch) under a new **CLI Tools** subsection in Extensions & Integrations
- onWatch is an open-source Go CLI that tracks AI API quota usage across 7 providers including Anthropic (Claude Code)
- Background daemon, ~15MB binary, <50MB RAM, zero telemetry, GPL-3.0, 342+ stars
- Works with Claude Code, Cline, Roo Code, and Kilo Code
- Includes a Material Design 3 web dashboard with dark/light mode

## Why it fits this list

onWatch is directly relevant to Claude Code users who need to monitor their Anthropic API quota alongside other AI providers. It complements the existing Claude Usage Tracker browser extension with a local-first CLI alternative.