### PR TITLE
Add ORCH — CLI runtime for Claude Code agent orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🤝 Agent Orchestration Tools
+
+- [ORCH](https://github.com/oxgeneral/ORCH) - CLI runtime that turns Claude Code, Codex, Cursor, and OpenCode into a coordinated AI agent team. Managed task queue with state machine (todo→in_progress→review→done), auto-retry, inter-agent messaging, shared context store, goals system, TUI dashboard. 1647 tests, MIT, TypeScript.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
## What

Adds [ORCH](https://github.com/oxgeneral/ORCH) to a new **🤝 Agent Orchestration Tools** subsection under **🧩 Extensions & Integrations**.

## Why this placement

ORCH extends Claude Code workflows by coordinating multiple AI agent instances — it's an integration/extension layer, not a standalone application. The new subsection captures a distinct category that doesn't exist yet in the list.

## Entry

```
- [ORCH](https://github.com/oxgeneral/ORCH) - CLI runtime that turns Claude Code, Codex, Cursor, and OpenCode into a coordinated AI agent team. Managed task queue with state machine (todo→in_progress→review→done), auto-retry, inter-agent messaging, shared context store, goals system, TUI dashboard. 1647 tests, MIT, TypeScript.
```

## Key features

- **Multi-adapter**: Claude Code, OpenCode, Codex, Cursor, shell scripts
- **State machine**: `todo → in_progress → review → done` with auto-retry on failure
- **Inter-agent messaging**: agents communicate via `orch msg send`
- **Shared context store**: agents share key-value state across tasks
- **Goals system**: high-level goals decompose into task queues
- **TUI dashboard**: real-time Ink/React terminal UI
- **Programmatic API**: `@oxgeneral/orch` exports full engine for embedding
- 1647 tests, MIT license, TypeScript strict mode

## Links

- GitHub: https://github.com/oxgeneral/ORCH
- npm: https://www.npmjs.com/package/@oxgeneral/orch