### PR TITLE
Add Parallel Code to Desktop Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [Parallel Code](https://parallelcode.app) - Desktop app for running multiple Claude Code agents simultaneously in isolated git worktrees.
 
 ---
 


### PR DESCRIPTION
Parallel Code is an open-source desktop app for running multiple Claude Code (and other AI coding) agents in parallel, each in isolated git worktrees. Features built-in diff viewer and one-click merge.