### PR TITLE
Add Reporecall — local codebase memory with hooks + MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
+- [Reporecall](https://github.com/proofofwork-agency/reporecall) -  Local codebase memory with AST indexing (22 languages), call graphs, and hybrid search. Hooks + MCP server.
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
## What it does

[Reporecall](https://github.com/proofofwork-agency/reporecall) gives Claude Code a codebase memory so it stops wasting tokens rediscovering your code.

**The problem:** Claude Code spends its first moves grepping and reading files to understand a codebase it's already seen. On large repos this burns through context window and token budget before real work starts.

**The solution:** Reporecall pre-indexes your codebase using Tree-sitter AST parsing (22 languages), builds call graphs, and injects relevant context via a hook in ~5ms — before Claude starts thinking. No grep chains, no exploration loops.

- Hybrid keyword + vector search
- Call graph traversal (callers + callees)
- Also works as an MCP server
- 3-8x reduction in token usage for context gathering

npm: `@proofofwork-agency/reporecall`