### PR TITLE
Add Iris MCP Server — agent eval for MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [iris-eval/mcp-server](https://github.com/iris-eval/mcp-server) -  The agent eval standard for MCP. Scores output quality, catches safety failures, enforces cost budgets. Zero code changes — auto-discovered via MCP config. [Playground](https://iris-eval.com/playground).
 
 ---
 


### PR DESCRIPTION
Adds [Iris MCP Server](https://github.com/iris-eval/mcp-server) to the MCP section.

The agent eval standard for MCP — scores output quality, catches safety failures (PII, hallucinations, prompt injection), and enforces cost budgets. Auto-discovered via MCP config, zero code changes required.

- npm: `@iris-eval/mcp-server` (370+ downloads)
- Interactive playground: [iris-eval.com/playground](https://iris-eval.com/playground)
- MIT licensed, self-hosted
- Listed on Official MCP Registry + Glama (A/A/A score)