### PR TITLE
Add brood-box to Agent Sandboxing

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🛡️ Agent Sandboxing
+
+- [brood-box](https://github.com/stacklok/brood-box) -  Run Claude Code inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
Adds [brood-box](https://github.com/stacklok/brood-box) under a new **Agent Sandboxing** subsection in Extensions & Integrations.

brood-box is an open-source CLI tool (Apache-2.0) that runs Claude Code (and other coding agents like Codex and OpenCode) inside hardware-isolated microVMs powered by libkrun. Features include:

- **Snapshot isolation** — COW workspace snapshots with interactive per-file review before changes are flushed back
- **Egress control** — DNS-aware network policies restrict what the agent can reach
- **MCP authorization** — Cedar-based profiles (observe, safe-tools, custom) to restrict agent MCP operations
- **Sub-second boot** — lightweight microVMs via the [go-microvm](https://github.com/stacklok/go-microvm) framework

Built by [Stacklok](https://github.com/stacklok). Actively maintained with commits within the last week.