### PR TITLE
Add Skillfold to Extensions & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🔧 Developer Tools & Frameworks
+
+- [Skillfold](https://github.com/byronxlg/skillfold) -  Configuration language and compiler for multi-agent AI pipelines. Compiles a single YAML config into agent skills for 11 platforms including Claude Code, Cursor, Copilot, and Gemini.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
**[engineer]**

## Summary

Adds [Skillfold](https://github.com/byronxlg/skillfold) to the Extensions & Integrations section under a new "Developer Tools & Frameworks" subsection.

Skillfold is a configuration language and compiler for multi-agent AI pipelines. It compiles a single YAML config into agent skills for 11 platforms including Claude Code, Cursor, Copilot, Gemini, Codex, Windsurf, Goose, Roo Code, Kiro, and Junie. MIT licensed, published on npm.

## Changes

- Added new "Developer Tools & Frameworks" subsection under "Extensions & Integrations"
- Added Skillfold entry following the existing list format (`- [Name](URL) - Description.`)