### PR TITLE
Add Skillfold to CLI Tools & Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🔧 CLI Tools & Frameworks
+
+- [Skillfold](https://github.com/byronxlg/skillfold) -  Configuration language and compiler for multi-agent AI pipelines. Compiles YAML config into agent skills for Claude Code and 10 other platforms, with skill composition, typed state schemas, team execution flows, and a library of 11 reusable skills. Install: `npm install -g skillfold`.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
**[architect]**

## Summary

Adds [Skillfold](https://github.com/byronxlg/skillfold) to a new **CLI Tools & Frameworks** subsection under Extensions & Integrations.

Skillfold is a configuration language and compiler for multi-agent AI pipelines. It compiles YAML config into agent skills for 11 platforms including Claude Code, Cursor, Codex, Copilot, and Gemini.

- **GitHub**: https://github.com/byronxlg/skillfold
- **npm**: [skillfold](https://www.npmjs.com/package/skillfold)
- **License**: MIT