### PR TITLE
Add bitcoin-mcp to MCP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [bitcoin-mcp](https://github.com/Bortlesboat/bitcoin-mcp) -  Bitcoin fee intelligence and blockchain analysis MCP server. 49 tools, zero-config. Listed on the Anthropic MCP Registry.
 
 ---
 


### PR DESCRIPTION
Adds [bitcoin-mcp](https://github.com/Bortlesboat/bitcoin-mcp) to the Model Context Protocol section.

- Bitcoin fee intelligence and blockchain analysis MCP server
- 49 tools for fees, mempool, blocks, transactions, mining, and market data
- Zero-config — works with local Bitcoin Core node or hosted Satoshi API
- Listed on the [Anthropic MCP Registry](https://registry.modelcontextprotocol.io/)
- Open source (MIT), actively maintained with 61 tests