### PR TITLE
Add SkillCheck-Free skill validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🔧 Developer Tools
+
+- [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) -  Free SKILL.md validator with 30+ checks across structure, naming, and semantics. MIT licensed.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
## Summary

- Adds [SkillCheck-Free](https://github.com/olgasafonova/SkillCheck-Free) to the Extensions & Integrations section under a new Developer Tools subsection
- SkillCheck-Free is a free, MIT-licensed SKILL.md validator with 30+ checks across structure, naming, and semantics
- Helps Claude Code users validate their skill definitions before publishing