### PR TITLE
Add BotVa to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### 🤖 Bots & Platforms
+
+- [BotVa](https://github.com/cohe4ko/BotVa) -  Self-hosted multi-bot Telegram platform powered by Claude AI with MCP integration, persistent memory, and team coordination.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
## Summary

- Adds [BotVa](https://github.com/cohe4ko/BotVa) to the **Applications > Bots & Platforms** subsection
- BotVa is a self-hosted multi-bot Telegram platform powered by Claude AI with MCP integration, persistent memory, and team coordination
- MIT licensed, open source, actively maintained

## Checklist

- [x] Follows the `- [Name](URL) - Description.` format
- [x] Added to the bottom of the relevant category
- [x] Description is short, starts with a capital, ends with a period
- [x] Project is open source with a public repository
- [x] Project has good documentation with installation and usage instructions