### PR TITLE
Add claw-army/claude-node - Python subprocess bridge for Claude Code CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Premium pricing for >200K tokens. Full comparison: [Models overview](https://pla
 
 - [claude-agent-sdk-python](https://github.com/anthropics/claude-agent-sdk-python) -  Python Agent SDK. [Docs](https://platform.claude.com/docs/en/agent-sdk/overview)
 - [claude-agent-sdk-typescript](https://github.com/anthropics/claude-agent-sdk-typescript) -  TypeScript Agent SDK.
+- [claw-army/claude-node](https://github.com/claw-army/claude-node) -  Python subprocess bridge for Claude Code CLI, giving Python code direct access to Claude Code native capabilities via stream-json.
 
 **Starters**
 


### PR DESCRIPTION
Adds [claw-army/claude-node](https://github.com/claw-army/claude-node) to the Agent SDKs section.

- Python subprocess bridge for Claude Code CLI
- Gives Python code direct access to Claude Code native capabilities via stream-json
- Enables building Python applications that leverage Claude Code capabilities