### PR TITLE
Add Claude Code Organizer to CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🛠️ CLI Tools
+
+- [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) - Web dashboard and MCP server for organizing Claude Code configs across scope hierarchy. Scans 11 categories in ~/.claude/, drag-and-drop between scopes, undo, bulk operations.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
## Addition

Adding [Claude Code Organizer](https://github.com/mcpware/claude-code-organizer) to a new **CLI Tools** sub-section under Extensions & Integrations.

## Why it should be included

- Web dashboard and MCP server for organizing Claude Code configs across scope hierarchy
- Scans 11 categories in ~/.claude/, shows inheritance tree, drag-and-drop between scopes
- 90+ GitHub stars in first week, actively maintained, MIT license
- Zero dependencies, one-command install: `npx @mcpware/claude-code-organizer`

## Format

Follows the `- [Name](URL) - Description.` format as specified in contributing guidelines.