### PR TITLE
Add FlyCrys to Desktop applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [FlyCrys](https://github.com/SergKam/FlyCrys) - Native Linux GUI for Claude Code agents built with Rust and GTK4, featuring file tree, text viewer, embedded terminal, and multi-workspace support.
 
 ---
 


### PR DESCRIPTION
## What

Add [FlyCrys](https://github.com/SergKam/FlyCrys) to the **Applications > Desktop** section.

FlyCrys is a **native Linux desktop GUI for Claude Code agents**.

## Tech Stack

- **Rust** + **GTK4** + **VTE4** + **WebKitGTK**

## Features

- File tree browser
- Syntax-highlighted text viewer
- Markdown preview (WebKitGTK)
- Git diff viewer
- Embedded terminal (VTE4)
- Agent chat interface
- Multiple workspaces with independent agents
- Slash commands

## License

MIT

## Link

https://github.com/SergKam/FlyCrys