### PR TITLE
Add Claude Code Cheat Sheet to Community Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [40+ Claude Code Tips](https://github.com/ykdojo/claude-code-tips#readme) -  Tips for getting the most out of Claude Code, including a custom status line script, cutting the system prompt in half, using Gemini CLI as Claude Code's minion, and Claude Code running itself in a container. Also includes the dx plugin for GitHub Actions debugging, conversation cloning, and handoffs.
 - [My Experience With Claude Code After 2 Weeks of Adventures](https://sankalp.bearblog.dev/my-claude-code-experience-after-2-weeks-of-usage/) - Part 1: Real-world lessons on using a `TODO.md` file to keep Claude on track, managing costs, and why it often outperforms Cursor for complex refactors.
 - [A Guide to Claude Code 2.0 and getting better at using coding agents](https://sankalp.bearblog.dev/my-experience-with-claude-code-20-and-how-to-get-better-at-using-coding-agents/#setup) - Part 2: A deep dive into the 2.0 update, focusing on the "Agent Manager" mindset, context engineering, and using sub-agents for larger codebases.
+- [Claude Code Cheat Sheet](https://cc.storyfox.cz/) - Complete one-page printable reference with all shortcuts, commands, CLI flags, MCP config, memory, skills, and agents. Auto-updated daily from official docs. Available in EN, ZH, JA, KO.
 
 ---
 


### PR DESCRIPTION
Adding [Claude Code Cheat Sheet](https://cc.storyfox.cz/) to the Community Guides section.

- One-page printable reference with all shortcuts, commands, CLI flags, MCP config, memory, skills, and agents
- Auto-updated daily from official docs via a multi-agent pipeline
- Available in 4 languages: [EN](https://cc.storyfox.cz/), [ZH](https://cc.storyfox.cz/zh/), [JA](https://cc.storyfox.cz/jp/), [KO](https://cc.storyfox.cz/kr/)
- Hit HN frontpage with 130k+ pageviews