### PR TITLE
Add Flock to Desktop Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [Flock](https://github.com/Divagation/flock) -  Native macOS (Swift/AppKit) multiplexer for running multiple Claude Code sessions in parallel with agent mode, themes, and prompt compression.
 
 ---
 


### PR DESCRIPTION
## What is Flock?

[Flock](https://github.com/Divagation/flock) is a native macOS (Swift/AppKit) terminal multiplexer purpose-built for running multiple Claude Code sessions in parallel.

## Key Features

- **Agent mode** with kanban board for tracking parallel AI tasks
- **7 built-in themes** for visual session differentiation
- **Broadcast mode** to send commands to all sessions simultaneously
- **Wren prompt compression** for token savings
- **Usage tracking** with per-session analytics
- Built with Swift/AppKit as a true native macOS app

## Section

Added to **Desktop Applications** section, matching the existing entry format.