### PR TITLE
Add cancer.coach — AI skills framework for cancer patients

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### 🏥 Health & Medical
+
+- [cancer.coach](https://cancer.v1be.codes) -  AI skills framework empowering cancer patients to take an active role in treatment decisions. Includes five specialized skills (assess, treat, navigate, monitor, strategist) for the full cancer journey. Install: `npx skills add cancer-coach/skills`. [GitHub](https://github.com/cancer-coach/skills)
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
## Summary

Adds [cancer.coach](https://cancer.v1be.codes) to a new **Health & Medical** subsection under Applications.

**What it is:** A patient-facing AI skills framework for the full cancer journey. Five specialized Claude skills (cc-assess, cc-treat, cc-navigate, cc-monitor, cc-strategist) help patients pursue comprehensive diagnostics, parallel treatment options, clinical trial navigation, and systematic monitoring.

**Key details:**
- Install: `npx skills add cancer-coach/skills`
- Works inside Claude, Codex, Cursor, and other AI assistants
- GitHub: https://github.com/cancer-coach/skills
- Category: Health & Medical (new subsection under Applications)

**Why it belongs here:** It's the only patient-facing AI skills framework for cancer — a genuinely novel use of Claude skills for a high-stakes, underserved domain. It doesn't duplicate anything currently listed.