### PR TITLE
Add Product Org OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 ### 🧠 Claude Code Skills & Plugins
 
-- [Product Org OS](https://github.com/yohayetsion/product-org-os) - An entire product organization as AI agents with 133 skills, 13 agents, and 2 gateways for product management, strategy, GTM, and competitive intelligence.
+- [Product Org OS](https://github.com/yohayetsion/product-org-os) - An entire product organization as AI agents with 150+ skills, 12 agents, 2 gateways, and 38 knowledge packs for product management, strategy, GTM, and competitive intelligence.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🧠 Claude Code Skills & Plugins
+
+- [Product Org OS](https://github.com/yohayetsion/product-org-os) - An entire product organization as AI agents with 133 skills, 13 agents, and 2 gateways for product management, strategy, GTM, and competitive intelligence.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
## What

Adds [Product Org OS](https://github.com/yohayetsion/product-org-os) to the Extensions & Integrations section under a new "Claude Code Skills & Plugins" subsection.

## About Product Org OS

An entire product organization as AI agents — 133 skills, 13 agents, and 2 gateways for product management, strategy, GTM, and competitive intelligence. Built as a Claude Code plugin.

- **Open source**: MIT license
- **Actively maintained**: Regular commits (last commit within days)
- **Good documentation**: Full installation guide, skill catalog, and usage instructions
- **Homepage**: https://yohayetsion.github.io/product-org-os/
- **GitHub**: https://github.com/yohayetsion/product-org-os

## Why a new subsection?

The existing Extensions & Integrations section has IDE Extensions and Browser Extensions but no category for Claude Code skills/plugins. As the Claude Code ecosystem grows, this subsection provides a natural home for similar projects.