### PR TITLE
Add ClawBox to Desktop applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [ClawBox](https://github.com/coderkk1992/clawbox) -  Run OpenClaw AI agent (powered by Claude) in a sandboxed Linux VM with native macOS UI. 5-minute setup, no CLI required.
 
 ---
 


### PR DESCRIPTION
Adding [ClawBox](https://github.com/coderkk1992/clawbox) to the Desktop applications section.

ClawBox is a native macOS app that runs OpenClaw AI agent (which uses Claude) in a sandboxed Linux VM.

**Features:**
- Native macOS UI (Tauri + React)
- AI runs in isolated VM via Lima - safe from host system
- Supports Claude and GPT models
- 5-minute setup with no CLI required
- Drag & drop file sharing
- Multiple agent personalities

Open source and free.