### PR TITLE
Add Claudoscope to Applications > Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [Claudoscope](https://github.com/cordwainersmith/claudoscope) - Native macOS menu bar app for Claude Code session analytics and observability. Token/cost tracking, full-text search, real-time secret detection, and config health linting. Swift/SwiftUI, Homebrew install, fully offline.
 
 ---
 


### PR DESCRIPTION
## What is Claudoscope?

[Claudoscope](https://github.com/cordwainersmith/claudoscope) is a free, open-source native macOS menu bar app that provides observability into Claude Code sessions.

### Key features:
- Reads local JSONL session files from `~/.claude/projects/`
- Session history browsing with full-text search
- Token and cost analytics with model breakdown
- Real-time secret detection in session logs
- Config Health linting (44 rules across 4 categories)
- Surfaces memory, plugins, skills, hooks, and settings
- Built with Swift/SwiftUI, distributed via Homebrew cask
- Completely offline, zero API calls, no telemetry

### Install:
```bash
brew tap cordwainersmith/tap
brew install --cask claudoscope
```

### Links:
- GitHub: https://github.com/cordwainersmith/claudoscope
- Website: https://claudoscope.com/