### PR TITLE
Add operant-mcp to MCP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [operant-mcp](https://github.com/operantlabs/operant-mcp) -  Open-source MCP server with 51 security testing tools for pentesting, vulnerability scanning, and security auditing. MIT licensed.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [operant-mcp](https://github.com/operantlabs/operant-mcp) to the Model Context Protocol (MCP) section.

- Open-source MCP server with 51 security testing tools
- Covers pentesting, vulnerability scanning, and security auditing
- MIT licensed

## Details

operant-mcp is a comprehensive security testing MCP server that brings 51 tools directly into your AI workflow, including SQL injection testing, XSS detection, CORS misconfiguration checks, recon tools, PCAP analysis, and more.

- GitHub: https://github.com/operantlabs/operant-mcp
- License: MIT