### PR TITLE
Add Overloop CLI and Signals CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### 🔧 CLI Tools
+
+- [Overloop CLI](https://github.com/sortlist/overloop-cli) -  AI-powered outbound engine. Source contacts (450M+ database), run multi-channel campaigns (email + LinkedIn), enroll prospects, and manage conversations. JSON output. `npm install -g overloop-cli`
+- [Signals CLI](https://github.com/sortlist/signals-cli) -  Intent signal monitoring for B2B. Track LinkedIn engagement, keyword posters, job changers, and funding events. JSON output. `npm install -g signals-sortlist-cli`
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
## Summary

- Adds **[Overloop CLI](https://github.com/sortlist/overloop-cli)** and **[Signals CLI](https://github.com/sortlist/signals-cli)** under a new **CLI Tools** subsection within **Applications**.
- Overloop CLI is an AI-powered outbound engine built on Claude: source contacts (450M+ database), run multi-channel campaigns (email + LinkedIn), enroll prospects, manage conversations. JSON output, installs via `npm install -g overloop-cli`.
- Signals CLI monitors B2B intent signals: LinkedIn engagement, keyword posters, job changers, funding events. JSON output, installs via `npm install -g signals-sortlist-cli`.

Both tools are Claude-powered, open-source, and actively maintained. They fit naturally under Applications as CLI tools in the Claude ecosystem.

## Checklist

- [x] Entries match the existing format (`[Name](url) - description`)
- [x] Tools are actively maintained
- [x] Clear documentation available in linked repos