### PR TITLE
Add WhereMyTokens — Claude Code token usage monitor for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) -  Windows system tray app for monitoring Claude Code token usage in real time. Displays per-session token counts, costs, context window progress, rate limit bars (5h/1w), activity heatmaps, and model breakdowns. Integrates as a Claude Code statusLine plugin for live data without API polling.
 
 ---
 


### PR DESCRIPTION
## What is this?

[WhereMyTokens](https://github.com/jeongwookie/WhereMyTokens) is a Windows system tray app for monitoring Claude Code token usage in real time.

## Features

- **Live session tracking** — detects running Claude Code sessions (Terminal, VS Code, Cursor, Windsurf, etc.) with per-session state: `active` / `waiting` / `idle` / `compacting`
- **Rate limit bars** — 5h and 1w usage from Anthropic's API, with progress bars and time-to-reset counters
- **Claude Code bridge** — registers as a Claude Code `statusLine` plugin for live rate-limit data without API polling
- **Context window warnings** — per-session compact warnings at 50% / 80% / 95%+ inline in the session list
- **Tool usage bars** — proportional color bar + top-3 tool names (Bash, Edit, Read…) per session
- **Activity heatmaps** — 7-day and 5-month GitHub-style calendar grids; hourly distribution; 4-week comparison chart
- **Model breakdown** — per-model token and cost totals across all time
- **Cost display** — USD or KRW, with subscription equivalent value vs. actual API cost

## Why it belongs here

It's a native desktop application built specifically around Claude — integrates with Claude Code's official `statusLine` plugin API and reads local session JSONL files. Open source (MIT), actively maintained.

- **Repo**: https://github.com/jeongwookie/WhereMyTokens
- **License**: MIT
- **Platform**: Windows 10 / 11