### PR TITLE
Add CliDeck to Applications > Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+- [CliDeck](https://github.com/rustykuntz/clideck#readme) - Local browser dashboard for managing multiple AI coding agents including Claude Code, Codex, and Gemini CLI in a WhatsApp-like interface with live status, session resume, autopilot routing, and full control from a phone while away.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
## Summary
Adds CliDeck to the Applications > Desktop section.

## Project
- **Repository:** https://github.com/rustykuntz/clideck
- **Type:** Open-source local desktop tool (MIT)
- **Why include:** CliDeck is a browser dashboard for managing Claude Code sessions alongside other AI coding agents. it runs locally, shows live agent status via OpenTelemetry signals, resumes sessions across restarts, and routes work between agents with autopilot. full control from a phone while away via E2E encrypted relay.

## Key features
- WhatsApp-like interface for managing multiple Claude Code sessions
- Live status detection — see which agent is working, idle, or waiting
- Session resume across restarts
- Autopilot routes work between agents autonomously (~50 tokens per decision)
- Plugin system (Voice Input, Trim Clip, Autopilot)
- 15 built-in themes

## Checklist
- [x] Single suggestion PR
- [x] Correct list format (`- [Name](URL) - Description.`)
- [x] Short, clear description with proper capitalization/punctuation
- [x] Added to the relevant existing category
- [x] Open source with public repo
- [x] Actively maintained