### PR TITLE
Add Onepilot to Applications > Mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### 📱 Mobile
+
+- [Onepilot](https://onepilotapp.com) -  iOS app for SSHing into remote servers to run Claude Code and other CLI tools from your phone, plus one-click AI agent deployment via OpenClaw.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
Adds [Onepilot](https://onepilotapp.com) under a new **Mobile** subsection in **Applications**.

Onepilot is an iOS app for SSHing into remote servers to run Claude Code and other CLI coding tools from your phone, plus one-click AI agent deployment via OpenClaw. It fills a gap in the list — there are Desktop entries but no mobile apps yet.

- Added a Mobile subsection after the existing Desktop subsection
- Entry follows the same format used throughout the list