### PR TITLE
Add resume-cli - TUI for resuming AI coding sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### ⌨️ CLI Tools
+
+- [resume-cli](https://github.com/inevolin/resume-cli#readme) -  TUI to resume AI coding sessions across Claude Code, GitHub Copilot CLI, and Codex from a single interactive picker; supports cross-tool context loading.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
## Summary

Adds `resume-cli` ([npm: `ai-resume-cli`](https://www.npmjs.com/package/ai-resume-cli)) to the **Extensions & Integrations** section under a new **CLI Tools** subsection.

- **GitHub:** https://github.com/inevolin/resume-cli
- **What it does:** TUI to resume AI coding sessions across Claude Code, GitHub Copilot CLI, and Codex from a single interactive picker; supports cross-tool context loading.

The new `### ⌨️ CLI Tools` subsection is placed after Browser Extensions within the existing Extensions & Integrations section, matching the existing entry format exactly.