### PR TITLE
Add toprank — SEO + Google Ads plugin for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
+- [toprank](https://github.com/nowork-studio/toprank) -  Open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. Pulls real Search Console, PageSpeed Insights, and Google Ads API data, then ships fixes — meta tags, JSON-LD schema, keyword bids — directly to source or CMS.
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
Adds **toprank** under the Claude Code section.

toprank is an open-source (MIT) Claude Code plugin with 9 SEO and Google Ads skills. It connects Google Search Console, PageSpeed Insights, and the Google Ads API to audit traffic and wasted ad spend, then ships fixes directly — meta tag rewrites, JSON-LD schema markup, keyword bid adjustments, and content pushes to WordPress/Strapi/Contentful/Ghost.

- Source: https://github.com/nowork-studio/toprank
- License: MIT
- 100+ stars, actively maintained