### PR TITLE
Add BulkPublish MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [BulkPublish MCP](https://github.com/azeemkafridi/bulkpublish-api/tree/main/mcp-server) -  MCP server for social media publishing across 11 platforms — create posts, schedule, upload media, and track analytics. 29 tools. Install: `npx -y @bulkpublish/mcp-server`.
 
 ---
 


### PR DESCRIPTION
Adds [BulkPublish MCP Server](https://github.com/azeemkafridi/bulkpublish-api/tree/main/mcp-server) to the Model Context Protocol (MCP) section.

**BulkPublish** is an MCP server for social media publishing across 11 platforms (Twitter/X, Facebook, Instagram, LinkedIn, TikTok, YouTube, Pinterest, Threads, Bluesky, Mastodon, Telegram). It provides 29 tools for creating posts, scheduling, uploading media, and tracking analytics.

- npm: `@bulkpublish/mcp-server`
- Install: `npx -y @bulkpublish/mcp-server`