### PR TITLE
feat: add Claude Statistics – macOS menu bar app for Claude Code usage tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [Claude Statistics](https://github.com/sj719045032/claude-statistics) - Native macOS menu bar app for tracking Claude Code session usage, token costs, and Anthropic subscription limits in real time. Automatically discovers sessions from ~/.claude/projects/, shows per-model cost breakdowns and live 5h/7d subscription usage with reset countdown. 100% local, no uploads. Open source, MIT.
 
 ---
 


### PR DESCRIPTION
## What

Adds [Claude Statistics](https://github.com/sj719045032/claude-statistics) to the **Desktop Applications** section.

## About the project

Claude Statistics is a native macOS menu bar app for monitoring Claude Code sessions, token usage, and subscription costs in real time.

- Auto-discovers and parses JSONL transcripts from `~/.claude/projects/` — no setup required
- Daily/weekly/monthly/yearly cost analytics with interactive charts and per-model breakdowns (Opus/Sonnet/Haiku)
- Live subscription usage monitoring (5h/7d windows) via Anthropic's usage API, with reset countdown
- Built-in transcript viewer with full-text search
- One-click session resume in preferred terminal
- 100% local, nothing uploaded — uses existing OAuth token from macOS Keychain
- SwiftUI + AppKit, menu bar only (no dock icon)
- MIT licensed, Sparkle auto-updates

**GitHub:** https://github.com/sj719045032/claude-statistics
**License:** MIT
**Platform:** macOS 14+