### PR TITLE
docs: add Helium MCP to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,10 @@ _Practical walkthrough for integrating Claude Code into your development workflo
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) — Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) — Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🔌 MCP servers
+
+- [Helium](https://github.com/connerlambden/helium-mcp) — Real-time news intelligence, market data, options pricing, bias analysis via MCP.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
Adds **Helium** under Extensions & Integrations → MCP servers: [Helium MCP](https://github.com/connerlambden/helium-mcp) for real-time news intelligence, market data, options pricing, and bias analysis via MCP.

Made with [Cursor](https://cursor.com)