### PR TITLE
Add mcp-validate-action to Model Context Protocol section

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [MukundaKatta/mcp-validate-action](https://github.com/MukundaKatta/mcp-validate-action) -  GitHub Action that validates MCP server configs (`mcp.json`, `claude_desktop_config.json`) on every push — catches malformed frontmatter, invalid transports, and hardcoded API keys before they ship.
 
 ---
 


### PR DESCRIPTION
## What

Adds [MukundaKatta/mcp-validate-action](https://github.com/MukundaKatta/mcp-validate-action) to the Model Context Protocol section.

## Why it fits

The MCP section currently lists specs, courses, and the awesome-mcp-servers list — no CI tooling. This fills that gap.

mcp-validate-action is a GitHub Action that lints `mcp.json`, `.mcp.json`, and `claude_desktop_config.json` on every push. It catches the two most common classes of MCP config bugs before they ship:

- **Hardcoded API keys** in the `env` block (patterns like `sk-`, `ghp_`, `AIza`, `xoxb-`, `github_pat_`)
- **Malformed configs** — missing command/url, conflicting transports, invalid transport values

One-line install:

```yaml
- uses: MukundaKatta/mcp-validate-action@v1
```

## Checklist against contribution guidelines

- [x] **Open source**: MIT license
- [x] **Actively maintained**: v0.1.0 just released (April 2026)
- [x] **Meaningful functionality**: 10+ distinct validations, not a scaffold
- [x] **Good documentation**: README with options, examples, expected output
- [x] **Format**: `- [Name](URL) - Description.` (capital + period + concise)
- [x] **Individual PR** for this one suggestion only

## Disclosure

I'm the author. Happy to remove if maintainers prefer this stays a docs-only section.