### PR TITLE
Add OpenTwins to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### 🤖 Agents
+
+- [OpenTwins](https://github.com/Open-Twin/opentwins) -  Autonomous digital-twin agents that engage on 10 social platforms (Reddit, Twitter/X, LinkedIn, Bluesky, Threads, Medium, Substack, Dev.to, Product Hunt, Indie Hackers), powered by Claude Code and Chrome CDP.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
## Adding OpenTwins

**Project:** [OpenTwins](https://github.com/Open-Twin/opentwins) — autonomous AI agents across 10 social platforms, powered by Claude Code.

**Section:** 💻 Applications → 🤖 Agents (new subsection)

**Why it belongs:**
- End-user application built on Claude Code (uses the Claude Agent SDK under the hood)
- Open source, MIT, actively maintained (see [releases](https://github.com/Open-Twin/opentwins/releases) and CI)
- Has README, LICENSE, CONTRIBUTING, CODE_OF_CONDUCT, CHANGELOG, and tests
- Published on npm: https://www.npmjs.com/package/opentwins

**Note on the new subsection:** the existing **💻 Applications** section only had **🖥️ Desktop**. Rather than shoehorn an agent CLI under Desktop, I added a sibling **🤖 Agents** subsection. Happy to move it anywhere you prefer.

**Checklist:**
- [x] Link returns 200
- [x] No duplicate entry
- [x] Description is one sentence and follows the list's style (dash-separated)