### PR TITLE
Add DishRoll to Applications (Web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### 🌐 Web
+
+- [DishRoll](https://dishroll.netlify.app/) - AI-powered weekly meal planner using Claude Sonnet to generate personalised 7-day menus based on dietary needs, cuisine preferences, and grocery budget. Built with React, Vite, and Netlify Functions. [Source Code](https://github.com/samirasadov28-code/DishRoll)
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
Add DishRoll - an AI-powered weekly meal planner that uses Claude Sonnet to generate personalised 7-day menus. Added under a new "Web" subsection within Applications. Built with React, Vite, and Netlify Functions. MIT licensed, open source: https://github.com/samirasadov28-code/DishRoll