### PR TITLE
Add SwarmClaw and SwarmVault

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [SwarmClaw](https://github.com/swarmclawai/swarmclaw) - Self-hosted multi-agent runtime for Claude and 20+ other LLMs, with MCP client and server support, persistent memory, skills, schedules, sub-agent spawning, and connectors for Discord, Slack, Telegram, WhatsApp, Teams, and Matrix. Ships as Electron desktop app, CLI, and Docker. ([Website](https://swarmclaw.ai))
+- [SwarmVault](https://github.com/swarmclawai/swarmvault) - Local-first RAG knowledge vault with a Claude Code plugin, MCP server, and Obsidian integration. Compiles raw sources into a durable markdown wiki with a knowledge graph and hybrid SQLite FTS plus embeddings. ([Website](https://swarmvault.ai))
 
 ---
 


### PR DESCRIPTION
## Summary

Adds two open-source, Claude-compatible desktop apps under Applications.

- **SwarmClaw** (https://github.com/swarmclawai/swarmclaw) is a self-hosted multi-agent runtime with MCP client and server support, persistent memory, skills, and connectors for Discord, Slack, Telegram, WhatsApp, Teams, and Matrix. Supports Claude, OpenAI, Google, Ollama, and 20+ other LLM providers. Ships as Electron desktop app, CLI, and Docker.
- **SwarmVault** (https://github.com/swarmclawai/swarmvault) is a local-first RAG knowledge vault with a Claude Code plugin, MCP server, and Obsidian integration. Compiles raw sources (books, notes, transcripts, files, URLs, code) into a durable markdown wiki with a knowledge graph and hybrid SQLite FTS plus embeddings.

Both projects are MIT licensed, open source, actively maintained, and integrate with Claude.