### PR TITLE
Add WhatsApp Assistant AI to Agents & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ AI assistant by Anthropic for complex reasoning, code generation, and analysis t
 - [⭐ Community Curated Lists](#-community-curated-lists)
 - [🧩 Extensions & Integrations](#-extensions--integrations)
 - [💻 Applications](#-applications)
+  - [🤖 Agents & Automation](#-agents--automation)
 - [📚 Educational Resources](#-educational-resources)
 - [👥 Community](#-community)
 
@@ -157,6 +158,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+
+### 🤖 Agents & Automation
+
+- [WhatsApp Assistant AI](https://github.com/marcelsYK/whatsup-assistant-ai) - Personal WhatsApp agent that handles appointment booking and administrative conversations on your behalf. Claude Sonnet 4.6 for conversation, Haiku 4.5 for classification. TypeScript, MIT.
 
 ---
 


### PR DESCRIPTION
Adds [WhatsApp Assistant AI](https://github.com/marcelsYK/whatsup-assistant-ai) — a TypeScript WhatsApp agent built on Claude that handles appointment booking and administrative conversations on the operator's behalf.

**Highlights:**
- Claude Sonnet 4.6 (conversation) + Haiku 4.5 (classification/summary)
- AES-256-GCM encryption at rest, scrypt KDF, prompt-injection sanitization
- 411 tests (360 unit + 51 integration against real Anthropic API), 94% branch coverage
- MIT licensed, actively maintained

I created a new `### 🤖 Agents & Automation` subsection under `## 💻 Applications` since no fitting subsection existed — happy to move it if you have a preferred location.