### PR TITLE
Add Claude Usage Widget – real-time desktop usage tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [Claude Usage Widget](https://github.com/JamesInvaderbdx/claude-usage-widget) - Lightweight Python desktop widget that displays your Claude.ai subscription usage (5h rolling window & 7-day limits) in real time, with reset times. Windows, tkinter-based.
 
 ---
 


### PR DESCRIPTION
## What

Adds [Claude Usage Widget](https://github.com/JamesInvaderbdx/claude-usage-widget) to the Desktop Applications section.

## Why

Lightweight Python/tkinter widget that shows Claude.ai Pro/Max users their 5h rolling window and 7-day usage limits in real time, with reset times — fills a gap that many users report (no easy way to check quota without digging into settings).

## Checklist

- [x] Fits existing Desktop section
- [x] Open source (MIT)
- [x] Actively maintained (first release April 2026)