### PR TITLE
Add solopreneur-skills to Community Curated Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) -  Team of specialized AI agents for building features and debugging.
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) -  100+ specialized AI agents for full-stack development maintained by the community.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated list of Model Context Protocol (MCP) servers for extending Claude's capabilities.
+- [Sudhakaran88/solopreneur-skills](https://github.com/Sudhakaran88/solopreneur-skills) - 42 Claude Code skills for solopreneurs: CRO, SEO, GTM, cold email, and pricing.
 
 ---
 


### PR DESCRIPTION
Adding [solopreneur-skills](https://github.com/Sudhakaran88/solopreneur-skills) to the **Community Curated Lists** section.

42 Claude Code skills for solopreneurs and solo founders covering CRO, SEO, GTM, cold email, pricing, churn prevention, and more. MIT licensed. Every skill is opinionated, research-backed (Reddit practitioners, CXL, Demand Curve, Princeton GEO paper, Unbounce, Klaviyo, Baymard), and written for one-person teams.

Let me know if any tweaks are needed — happy to adjust the description length or placement.