### PR TITLE
Add claude-snapshot to Claude Code Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🔌 Claude Code Plugins
+
+- [claude-snapshot](https://github.com/adhenawer/claude-snapshot) -  Portable `.tar.gz` snapshots of your Claude Code setup — export, diff, and apply settings/plugins/hooks/MCPs across machines with `.bak` rollback.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
## Description

Adds [claude-snapshot](https://github.com/adhenawer/claude-snapshot) under a new **🔌 Claude Code Plugins** sub-section inside `🧩 Extensions & Integrations`. I added the sub-heading since the list currently has IDE and Browser extension groups but no home for Claude Code plugins — happy to drop the heading and place the entry anywhere you prefer if that's a better fit.

## What is claude-snapshot?

Claude Code keeps your entire configuration (settings, plugins, hooks, MCP servers, global `CLAUDE.md`) in `~/.claude/`. Moving that across machines — personal to work, pre-format backup, onboarding a teammate — has no built-in mechanism; you rebuild it by hand.

claude-snapshot exports `~/.claude/` as a portable `.tar.gz` with a structured manifest, then applies it on the target machine with `\$HOME` path normalization, a diff-before-apply preview, and automatic `.bak` rollback of every overwritten file.

## Features

- 4 slash commands: `/snapshot:export`, `/snapshot:inspect`, `/snapshot:diff`, `/snapshot:apply`
- Captures settings, `CLAUDE.md`, hooks, plugin manifests, and MCP servers (\`mcpServers\` key only — OAuth tokens stay local)
- Zero network calls; plugin reinstall delegates to Claude Code's own `/plugin install`
- Cross-platform Node.js (macOS + Linux), 57 tests, CI matrix on Node 18/20/22

## Installation

\`\`\`bash
/plugin marketplace add adhenawer/claude-snapshot
/plugin install snapshot@claude-snapshot
\`\`\`

## Repo

https://github.com/adhenawer/claude-snapshot

## License

MIT