### PR TITLE
Add Codex Infinity to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ AI assistant by Anthropic for complex reasoning, code generation, and analysis t
 - [⭐ Community Curated Lists](#-community-curated-lists)
 - [🧩 Extensions & Integrations](#-extensions--integrations)
 - [💻 Applications](#-applications)
+  - [🏗️ Infrastructure](#️-infrastructure)
 - [📚 Educational Resources](#-educational-resources)
 - [👥 Community](#-community)
 
@@ -157,6 +158,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+
+### 🏗️ Infrastructure
+
+- [Codex Infinity](https://codex-infinity.com) - Run Claude Code autonomously on bare metal VPS with full root access. Supports Claude Max plans with no cloud timeouts.
 
 ---
 


### PR DESCRIPTION
## Summary

- Added [Codex Infinity](https://codex-infinity.com) under a new **Infrastructure** subsection within **Applications** -- run Claude Code autonomously on bare metal VPS with full root access, supporting Claude Max plans with no cloud timeouts.
- Updated the table of contents to include the new Infrastructure subsection.

The entry follows the existing formatting conventions of the list.

## Test plan

- [x] Entry matches the `- [Name](url) - Description.` format used throughout the README
- [x] Table of contents updated to reflect new subsection
- [x] Link verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)