### PR TITLE
Add Claude Skills subsection with planmysaas

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
 
+### 🎯 Claude Skills
+
+Markdown-based skill packages that drop into `~/.claude/skills/` and become slash commands inside Claude Code.
+
+- [planmysaas](https://github.com/creationskiro/planmysaas-claude-skill) -  Turns idea to a complete 8-stage SaaS blueprint (idea, research, analysis, architecture, features, frontend, phases, build playbook). Stage 8 ships a decision-grade, rubric-graded build playbook with dependency-ordered steps for Claude Code. Plain markdown, MIT, v1.0.0.
+
 ### 🔌 Model Context Protocol (MCP)
 
 Open standard (Linux Foundation) for connecting Claude to tools, repos, databases, tickets, and more. Supports one-click desktop extensions (`.mcpb` files).


### PR DESCRIPTION
## What this PR adds

A new **🎯 Claude Skills** subsection inside the existing **🛠️ Claude Code & Model Context Protocol (MCP)** section, seeded with one entry: [planmysaas](https://github.com/creationskiro/planmysaas-claude-skill).

## Why
The list currently covers Claude Code (the CLI), MCP servers, IDE extensions, and curated awesome-lists — but has no slot for the new wave of **markdown-based Claude Skills** (plain `~/.claude/skills/<name>/SKILL.md` packages that become slash commands inside Claude Code). Multiple `awesome-claude-skills` lists already exist as standalone repos; awesome-claude itself is missing this category.

This PR fills that gap with a small, well-framed subsection that other community skills can be added to over time.

## The seed entry: planmysaas

**License:** MIT · **Release:** v1.0.0

Turns a one-line idea into a complete 8-stage SaaS blueprint:

1. Idea refine
2. Research
3. Analysis (PMF, SWOT, TAM/SAM/SOM, Porter's 5F, BMC, GTM)
4. Architecture
5. Features
6. Frontend
7. Phases
8. Decision-grade build playbook (rubric-graded, dependency-ordered, leaf to root)

Stage 8 is the differentiator — instead of generic checklists, it produces 9–12 build steps each with goal, inputs, outputs, an 8–14 box acceptance rubric, edge cases, common pitfalls, quality bar, and a stop-and-review gate.

### Install
```bash
git clone https://github.com/creationskiro/planmysaas-claude-skill ~/.claude/skills/planmysaas
```
Then `/planmysaas "<your idea>"` from inside Claude Code.

Happy to split this into two PRs (section first, entry second) if that's preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)