### PR TITLE
Add DishRoll to Applications section

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### 🌐 Web
+
+- [DishRoll](https://dishroll.netlify.app/) -  AI-powered weekly meal planner that generates personalized 7-day menus and smart shopping lists, built with Claude Sonnet.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
Adds DishRoll under a new Web subsection in the Applications section. DishRoll is an open-source, Claude Sonnet-powered weekly meal planner that generates personalized 7-day menus based on cuisine preferences, dietary needs, and budget, and builds a smart deduplicated shopping list. Built with React + Vite + Netlify Functions + Anthropic Claude. MIT licensed.

Link: https://dishroll.netlify.app/
Repo: https://github.com/samirasadov28-code/DishRoll