### PR TITLE
Add Voidly MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [Voidly MCP Server](https://github.com/voidly-ai) -  83+ tools for censorship intelligence (19.6M OONI measurements) and encrypted agent-to-agent messaging. Install: `npx @voidly/mcp-server`.
 
 ---
 


### PR DESCRIPTION
Adds Voidly MCP Server to the Claude Code & MCP section.

## What it is

`@voidly/mcp-server` — 83+ MCP tools across two categories:

- **Censorship Intelligence (27 tools)** — 19.6M live OONI measurements across 126 countries, 5,356 citable incidents. Check domain blocking, country status, risk forecasts, platform/ISP risk scores, election risk briefings, probe network data.
- **Encrypted Agent-to-Agent Messaging (56 tools)** — register DIDs, send/receive E2E encrypted messages (Double Ratchet + X3DH + ML-KEM-768 post-quantum hybrid), encrypted channels, capabilities, tasks, attestations, memory store, federation, webhooks.

## Install

```bash
npx @voidly/mcp-server
```

Works with Claude Desktop, Claude Code, and Cursor.

## Links

- Source: https://github.com/voidly-ai
- npm: https://www.npmjs.com/package/@voidly/mcp-server
- Maintainer: @EmperorMew