### PR TITLE
Add VibeXForge to Applications (Web)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### 🌐 Web
+
+- [**VibeXForge**](https://www.vibexforge.com) - AI launch platform powered by **Claude Haiku 4.5**. Submit a project URL, Claude scores it across 5 dimensions (originality, clarity, UX potential, virality potential, investor curiosity), and the project evolves through 6 RPG stages on real engagement (plays, upvotes, shares).
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
Adding **VibeXForge** to `## 💻 Applications`.

The existing Applications section is desktop-only. Adding a new `### 🌐 Web` subsection — VibeXForge is the first entry.

**What it does**: AI launch platform powered by Claude Haiku 4.5. Users submit a URL or GitHub repo, Claude returns a structured review across 5 dimensions (originality, clarity, UX potential, virality potential, investor curiosity), and the project becomes a 16-bit pixel-art "hero card" that evolves through 6 RPG stages — Seed → Active → Growing → Breakout → Legend → Myth — based on real engagement metrics (plays, upvotes, shares).

**Why it fits**: directly powered by the Claude API. Uses `tool_use` + `messages.create` for structured JSON reviews. Open beta, source-available on [GitHub](https://github.com/alex-jb/vibex), runs locally with `npm run dev` in 30 seconds (mock data, no API keys required).

**Stack**: Next.js 16 · Supabase · Claude Haiku 4.5 · Remotion-driven per-project trailer pipeline · Bilingual EN/ZH.

Happy to merge into the existing Applications list as a flat bullet (without the Web subsection) if you prefer — just let me know.