### PR TITLE
Add claude-state to Claude Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
 
+### 🧰 Community Tools
+
+Open-source CLI tools and extensions that augment Claude Code workflows.
+
+- [claude-state](https://github.com/bansalbhunesh/claude-code-handoff) -  Persistent state for Claude Code: pre-compaction snapshots, project workspaces, signal-scored history, and a typed memory plugin contract. Pure bash + jq, no daemon.
+
 ### 🔌 Model Context Protocol (MCP)
 
 Open standard (Linux Foundation) for connecting Claude to tools, repos, databases, tickets, and more. Supports one-click desktop extensions (`.mcpb` files).


### PR DESCRIPTION
## What

Adds [claude-state](https://github.com/bansalbhunesh/claude-code-handoff) under a new `Community Tools` sub-section inside `Claude Code & Model Context Protocol (MCP)`.

## Why this fits

The current `Claude Code` subsection lists only official Anthropic resources (docs, product page, install command, Claude Desktop, Chrome extension). There's no home for community CLI tools that augment Claude Code. `claude-state` fills that gap and creates a place for similar future entries.

## Entry

- **Name:** claude-state
- **Repo:** https://github.com/bansalbhunesh/claude-code-handoff
- **License:** MIT
- **Description:** Persistent state for Claude Code: pre-compaction snapshots, project workspaces, signal-scored history, and a typed memory plugin contract. Pure bash + jq, no daemon.

Happy to rename the sub-section, move the entry, or skip the new sub-section and append directly under `Claude Code` if you'd prefer.