### PR TITLE
Add Claudex — persistent memory MCP server for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [Claudex](https://github.com/kunwar-shah/claudex) -  Persistent memory MCP server with FTS5 full-text search over Claude Code conversation history. Indexes `~/.claude/projects/` JSONL into SQLite, exposes 10 MCP tools, and ships a web UI for browsing past sessions. Install via `npm install -g @kunwarshah/claudex`.
 
 ---
 


### PR DESCRIPTION
## What

Adds [Claudex](https://github.com/kunwar-shah/claudex) to the **🔌 Model Context Protocol (MCP)** section.

```
- [Claudex](https://github.com/kunwar-shah/claudex) -  Persistent memory MCP server with FTS5 full-text search over Claude Code conversation history. Indexes `~/.claude/projects/` JSONL into SQLite, exposes 10 MCP tools, and ships a web UI for browsing past sessions. Install via `npm install -g @kunwarshah/claudex`.
```

## Why it belongs here

Claudex is a Claude-Code-specific MCP server that solves a real pain point for Claude users: persistent memory and search across the full conversation history that Claude Code already writes to `~/.claude/projects/`. Rather than re-pasting context or losing prior decisions, users get:

- 10 MCP tools (search, recall, list-projects, list-sessions, get-session, stats, etc.) wired directly into Claude Code
- SQLite + FTS5 full-text search over every prior message
- A web UI for browsing/exporting old sessions
- Local-only — no telemetry, no cloud, no network calls outside the MCP transport

## Project standards checklist (per `contributing.md`)

- [x] Open source — public GitHub repo
- [x] MIT licensed
- [x] Actively maintained — last push today (latest release v1.3.2)
- [x] Meaningful functionality beyond examples — full MCP server + web UI
- [x] Good documentation — README with install + usage + 10 tool reference
- [x] Community engagement — 86 stars, published to npm as `@kunwarshah/claudex`

## PR guidelines checklist

- [x] Searched existing entries — no duplicate
- [x] Single suggestion in this PR
- [x] Format: `- [Name](url) -  Description.`
- [x] Description starts with capital, ends with period
- [x] Added to bottom of the relevant category (🔌 MCP)
- [x] No trailing whitespace
- [x] Star count omitted (under the 1k threshold noted in the contributing guide)

Thanks for maintaining this list!