### PR TITLE
Add claws (TUI multiplexer for Claude Code sessions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### ⌨️ Terminal
+
+- [claws](https://github.com/dodontommy/claws#readme) -  TUI multiplexer for managing multiple Claude Code sessions in one window. Background daemon owns each session via PTY; sessions persist across SSH disconnects and reboots.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
Adds [claws](https://github.com/dodontommy/claws) — a TUI for running multiple Claude Code sessions at once.

A background daemon owns each `claude` process inside its own PTY; the TUI client connects to the daemon and shows all sessions in one window. Sessions stay alive across SSH disconnects and across reboots (the daemon resumes them via `claude --resume`). Cross-platform (macOS/Linux/Windows), MIT/Apache-2.0, in-place updater (`claws update`), and worktree-aware spawning so you can split work across git worktrees from inside the spawn form.

Installs via Homebrew, the cargo-dist installer scripts (curl/PowerShell), or `cargo install`. README has a screenshot of the dashboard.

Placed it under `💻 Applications` as a new `⌨️ Terminal` subsection (sibling to `🖥️ Desktop`), keeping the same `- [Name](URL) -  Description.` format used elsewhere in the file.