### PR TITLE
Add nowork-studio/awesome-ai-startups to Community Curated Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) -  Team of specialized AI agents for building features and debugging.
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) -  100+ specialized AI agents for full-stack development maintained by the community.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated list of Model Context Protocol (MCP) servers for extending Claude's capabilities.
+- [nowork-studio/awesome-ai-startups](https://github.com/nowork-studio/awesome-ai-startups#readme) -  Indie startup directory of bootstrapped, pre-seed, and angel-funded AI products built on Claude and other LLMs.
 
 ---
 


### PR DESCRIPTION
Adds [nowork-studio/awesome-ai-startups](https://github.com/nowork-studio/awesome-ai-startups) to **⭐ Community Curated Lists**.

It's an indie startup directory of bootstrapped, pre-seed, and angel-funded AI products — many of which are built on Claude (alongside other LLMs). Useful for the awesome-claude audience who wants to see what indie founders are shipping on top of Claude.

Format matches the existing `[owner/repo](url#readme) - description` style of the section.