### PR TITLE
Add ai-investment-skills to Community Curated Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [tellmefrankie/ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills) -  Battle-tested Claude Code skills for investment analysis: Options Flow Analyzer (filters lottery calls from P/C ratios), News Sentiment Engine, EV Calculator. Free tier + Pro Bundle ($29).
 
 ---
 


### PR DESCRIPTION
## What I'm adding

[tellmefrankie/ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills) — Claude Code skills for investment analysis.

**Skills included:**
- **Options Flow Analyzer** — filters lottery calls from P/C ratios before computing. Raw PCR 1.06 became 0.21 after stripping 98.4% lottery volume on CEG. Catches XLI institutional hedging (5.32 PCR, 5 sessions straight).
- **News Sentiment Engine** — processes 200+ articles, sentence-level scoring per ticker/sector
- **EV Calculator** — personalized EV adoption break-even with subsidy calculation
- **9-wave Investment Briefing Agent** (Pro) — coordinated multi-agent pipeline

Free tier available. MIT license. TypeScript + Claude API.

Fits the Community Curated Lists section alongside other specialized awesome lists.