### PR TITLE
Add pr-reviewer — Claude-powered GitHub PR CLI tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### 🖥️ CLI Tools
+
+- [tellmefrankie/pr-reviewer](https://github.com/tellmefrankie/pr-reviewer) -  AI-powered GitHub PR reviewer using Claude. Fetches the diff via gh CLI, returns structured review: Critical Issues, Suggestions, Verdict. `npm install -g pr-reviewer && pr-review 42`. TypeScript, MIT.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
## What I'm adding

[tellmefrankie/pr-reviewer](https://github.com/tellmefrankie/pr-reviewer) — CLI tool that reviews GitHub PRs using Claude API.

```bash
npm install -g pr-reviewer
pr-review 42          # by PR number
pr-review 42 --focus "auth logic"  # targeted review
```

**Output structure:**
- Summary
- Critical Issues (bugs, security, correctness)
- Suggestions (performance, maintainability)
- Nitpicks (style)
- Verdict: APPROVE / REQUEST_CHANGES / NEEDS_DISCUSSION

**Why it belongs in CLI Tools:**
- Pure CLI, no GUI
- Uses Claude API directly (claude-opus-4-6)
- gh CLI integration
- TypeScript, MIT, ~100 lines

Reviews a 200-line diff in ~22 seconds. Found an expired-token auth bypass that a 10-minute human review missed.