### PR TITLE
Add CLI Tools section with claude46 launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🔧 CLI Tools
+
+- [claude46](https://github.com/sparklingneuronics/claude-code-helpers#readme) -  Pinned Claude Code launcher for Opus 4.6. Runs a separate `claude46` command with model and Claude Code version pinned, while normal `claude` keeps updating. macOS, Linux, WSL, Windows.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
Adds a new "CLI Tools" subsection under Extensions & Integrations, with claude46 as the first entry.

claude46 is a small open-source launcher that pins both the model (Opus 4.6) and the Claude Code version (2.1.110) in a separate command, while leaving the normal `claude` CLI free to auto-update.

- One-liner install for macOS, Linux, WSL, and native Windows
- Auto-updates blocked for the pinned launcher only
- MIT licensed, no telemetry

Repo: https://github.com/sparklingneuronics/claude-code-helpers