### PR TITLE
feat: add Mneme HQ to Claude Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
 
+- [Mneme HQ](https://github.com/TheoV823/mneme) - Architectural governance layer for AI-assisted development. Enforces architectural decisions on every Claude Code call via CLAUDE.md integration; deterministic retrieval, no vector store required.
+
 ### 🔌 Model Context Protocol (MCP)
 
 Open standard (Linux Foundation) for connecting Claude to tools, repos, databases, tickets, and more. Supports one-click desktop extensions (`.mcpb` files).


### PR DESCRIPTION
**[Mneme HQ](https://github.com/TheoV823/mneme)** — architectural governance layer for AI-assisted development.

Added at the end of the **Claude Code** subsection, before the MCP section.

Mneme HQ enforces architectural decisions on every Claude Code call via CLAUDE.md integration. It deterministically retrieves relevant project decisions and injects them as structured context before generation, then detects constraint and anti-pattern violations in the output. No vector store or ML dependencies required.

- **License**: MIT
- **Language**: Python 3.11+