### PR TITLE
Add cleo - dependency manager for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
+- [Surt/cleo](https://github.com/Surt/cleo) -  npm-style dependency manager for Claude Code — install plugins, skills, agents, hooks, and MCP servers from one `cleo.json` manifest.
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
## What is cleo?

cleo is a dependency manager for the Claude Code ecosystem — `npm` / `pip` / `composer` for rules, skills, agents, commands, hooks, and MCP servers.

```bash
# As a Claude Code plugin (gets you /cleo-install, /cleo-require, etc.)
/plugin marketplace add https://github.com/Surt/cleo
/plugin install cleo@cleo

# Or as a standalone CLI
git clone https://github.com/Surt/cleo
cd cleo && pip install pyyaml
```

## Why it fits this list

One `cleo.json` manifest installs and version-pins everything `.claude/` needs across a team. Resolves `vendor/name` → `github.com/vendor/name` automatically. No registry signup. Lock file (`cleo.lock`) for reproducible installs across CI and developers.

- Repo: https://github.com/Surt/cleo
- License: GPL-3.0-or-later
- Status: early (v0.1.0) — manifest format may evolve before v1.0