### PR TITLE
Add Claude Code Memory Pack to Community Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [40+ Claude Code Tips](https://github.com/ykdojo/claude-code-tips#readme) -  Tips for getting the most out of Claude Code, including a custom status line script, cutting the system prompt in half, using Gemini CLI as Claude Code's minion, and Claude Code running itself in a container. Also includes the dx plugin for GitHub Actions debugging, conversation cloning, and handoffs.
 - [My Experience With Claude Code After 2 Weeks of Adventures](https://sankalp.bearblog.dev/my-claude-code-experience-after-2-weeks-of-usage/) - Part 1: Real-world lessons on using a `TODO.md` file to keep Claude on track, managing costs, and why it often outperforms Cursor for complex refactors.
 - [A Guide to Claude Code 2.0 and getting better at using coding agents](https://sankalp.bearblog.dev/my-experience-with-claude-code-20-and-how-to-get-better-at-using-coding-agents/#setup) - Part 2: A deep dive into the 2.0 update, focusing on the "Agent Manager" mindset, context engineering, and using sub-agents for larger codebases.
+- [Claude Code Memory Pack](https://github.com/nvwalj/claude-code-memory-pack#readme) - Free preview of stack-specific CLAUDE.md templates (Next.js, FastAPI, Swift, Go, ...) plus reusable hooks and slash commands, with a setup guide on how Claude Code layered memory loading actually works.
 
 ---
 


### PR DESCRIPTION
Adds [Claude Code Memory Pack](https://github.com/nvwalj/claude-code-memory-pack) to the **Community Guides** section under Educational Resources.

**What it is:** Stack-specific CLAUDE.md templates (Next.js, Vite+React, Node/TS, FastAPI, Python ML, Swift macOS, Swift iOS, Go CLI) + lifecycle hooks + slash commands, with a setup guide on how Claude Code's layered memory loading actually works.

**Why it fits here:** The free preview repo functions as a practical educational resource — it walks through the design of layered ~/.claude/CLAUDE.md → project/CLAUDE.md → subdir/CLAUDE.md, scoping per directory, why one giant CLAUDE.md falls apart, and when to graduate to plugins. The guide is the main pedagogical value; the templates make the lesson concrete.

**Compliance with the existing list:**
- ✅ Useful, scoped to Claude Code memory file structure (no overlap with the existing entries — those cover general usage, tips, refactoring; this covers memory file design specifically)
- ✅ Format follows the existing convention (`- [Name](url) - description.`)
- ✅ Open source (MIT) for the free preview
- ✅ Repository has a README + setup-guide preview that show the content quality before any reader has to commit

Repo: https://github.com/nvwalj/claude-code-memory-pack
License: MIT