### PR TITLE
Add dd-agents to Applications — domain-specific Claude app

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### ⚖️ Domain-Specific
+
+- [dd-agents](https://github.com/zoharbabin/due-diligence-agents) -  Open-source M&A due diligence: 13 agents (9 specialists + Judge + Executive Synthesis + Red Flag Scanner + Acquirer Intelligence) built on `claude-agent-sdk`. Interactive chat mode with 14 MCP tools. `pip install dd-agents`.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
Adds [dd-agents](https://github.com/zoharbabin/due-diligence-agents) under Applications > Domain-Specific.

**dd-agents** is an open-source M&A due diligence application built on `claude-agent-sdk`:

- 13 agents (9 specialists + Judge + Executive Synthesis + Red Flag Scanner + Acquirer Intelligence)
- Interactive chat mode with 14 MCP tools
- 38-step async pipeline with checkpoint/resume
- 3,714 unit tests, strict mypy, Apache 2.0
- `pip install dd-agents`

Added a "Domain-Specific" subsection under Applications since it's a full application built with Claude, not a plugin or extension.