### PR TITLE
Add: retro-daily — daily retro dashboard for Claude Code sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Code Theme](https://github.com/ashwingopalsamy/claude-code-theme) -  Claude-inspired VS Code theme pack with dark/light/high-contrast and brand variants, semantic token tuning, and ANSI-optimized terminal colors.
 - [Claude VSCode Theme](https://marketplace.visualstudio.com/items?itemName=AlvinUnreal.claude-vscode-theme) -  Thoughtful dark theme collection with classic and italic variants. Inspired by Claude AI with carefully balanced contrast and warm syntax colors.
 
+### 🪝 Hooks & Plugins
+
+- [retro-daily](https://github.com/gyanesh-m/retro-daily) -  `SessionStart` hook that prints a daily retro at the top of every Claude Code session: competency grade (0–100 / A–F), 14-day efficiency sparklines, year-long contributions heatmap, and a detached `claude -p` background worker that researches your weakest metrics on docs.anthropic.com and GitHub. Installs as a single-plugin marketplace; opt out of background workers with `RETRO_DAILY_NO_BACKGROUND_WORKERS=1`.
+
 ### 🌐 Browser Extensions
 
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.


### PR DESCRIPTION
## What this adds

**[retro-daily](https://github.com/gyanesh-m/retro-daily)** — a `SessionStart` hook that prints a daily retro at the top of every Claude Code session: competency grade (0–100 / A–F), 14-day efficiency sparklines, year-long contributions heatmap, and a detached `claude -p` background worker that researches your weakest metrics on `docs.anthropic.com` and GitHub and surfaces findings inline next session.

Installs as a single-plugin marketplace:

```
/plugin marketplace add gyanesh-m/retro-daily
/plugin install retro-daily@retro-daily
/reload-plugins
```

- Repo: https://github.com/gyanesh-m/retro-daily
- Demo: https://gyanesh-m.github.io/retro-daily/
- License: MIT

## Where it goes

Added under **🧩 Extensions & Integrations** in a new **🪝 Hooks & Plugins** subsection (between IDE Extensions and Browser Extensions). The list didn't have a dedicated home for Claude Code plugins or `SessionStart`/hook-based extensions yet — happy to relocate if you'd prefer it under Community Curated Lists or Applications instead.

## Security and privacy disclosure

Reads local Claude Code session history from `~/.claude/projects/*.jsonl`. Writes derived state, logs, scout results, and session tags under `~/.claude/metrics`. By default, `scout.sh` and `tag-sessions.sh` start detached, sandboxed `claude -p` background workers (scout uses `WebSearch`+`Write`; tag-sessions denies network). Set `RETRO_DAILY_NO_BACKGROUND_WORKERS=1` to disable both while keeping the dashboard rendering. Rate-limit scout frequency via `SCOUT_STALE_DAYS` (default 7).

## Why it fits

It's a hook first and a dashboard second — the SessionStart hook is the entry point and everything else flows from there.