### PR TITLE
Add career-ops to Applications (new CLI/Terminal subsection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### ⌨️ CLI / Terminal
+
+- [career-ops](https://github.com/santifer/career-ops) -  AI-powered job search orchestrator built on Claude Code. 14-skill pipeline that evaluates jobs, generates ATS-tailored PDFs, and tracks applications. Local-first, MIT.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
Adds [career-ops](https://github.com/santifer/career-ops) to the Applications section under a new `⌨️ CLI / Terminal` subsection.

## What it is
AI-powered job search orchestrator built on Claude Code. 14-skill pipeline that evaluates JDs, generates ATS-tailored PDFs, and tracks applications end-to-end. Local-first (CV never leaves the machine), MIT licensed.

## Why a new CLI/Terminal subsection
The Applications section currently has only a "🖥️ Desktop" subsection. As Claude Code itself is a terminal-first tool, a CLI/Terminal subsection seems natural for cataloging applications built on top of it. If you prefer a different placement, happy to adjust.

## Stats
- 46,422 GitHub stars (top 500 worldwide), 9,705 forks
- 3,167 Discord members, 55 contributors
- #1 globally on GitHub Topic `#job-search`
- MIT licensed
- Featured: Business Insider, WIRED Greece

## Format
Followed the existing convention (`- [Name](Link) -  Description.` with two spaces before description) used throughout the Applications section.

Thanks for maintaining this list.