### PR TITLE
Add AI Memory Reader to Applications / Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [AI Memory Reader](https://github.com/nvwalj/ai-memory-reader) -  Native macOS app that auto-discovers and renders memory files from Claude Code, Codex, Cursor, Gemini, Continue, Copilot, Aider, and OpenClaw — CLAUDE.md, AGENTS.md, daily memory entries, plus a chunked viewer for `~/.claude/projects/*.jsonl` session transcripts that crash VSCode on multi-MB files. Swift, ~3 MB universal binary, zero network calls, GPL-3.0.
 
 ---
 


### PR DESCRIPTION
Adds [AI Memory Reader](https://github.com/nvwalj/ai-memory-reader) to the **Applications / Desktop** section.

It's a native macOS app for browsing the memory files left by AI coding agents — auto-discovers Claude Code, Codex, Cursor, Gemini, Continue, Copilot, Aider, and OpenClaw directories, renders `CLAUDE.md` / `AGENTS.md` as markdown, and includes a chunked JSONL viewer for the multi-MB session transcripts under `~/.claude/projects/` that crash VSCode.

- Swift + SwiftUI, ~3 MB universal binary
- Zero network calls (optional once-a-day GitHub releases check)
- GPL-3.0, free, no signup
- Mac App Store build pending review

Disclosure: I'm the author. Fits the gap between text editors and IDE-tied agents — pairs well with the other CLI tools already in this list.