### PR TITLE
Add: ndesv21/socialclaw — social media publishing skill for 13 platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [langgptai/awesome-claude-prompts](https://github.com/langgptai/awesome-claude-prompts#readme) -  Collection of prompt examples designed to improve Claude interactions.
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) -  Team of specialized AI agents for building features and debugging.
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) -  100+ specialized AI agents for full-stack development maintained by the community.
+- [ndesv21/socialclaw](https://github.com/ndesv21/socialclaw) -  Agent skill for scheduling and publishing social media posts across 13 platforms (X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) via SocialClaw.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated list of Model Context Protocol (MCP) servers for extending Claude's capabilities.
 
 ---


### PR DESCRIPTION
Adds [ndesv21/socialclaw](https://github.com/ndesv21/socialclaw) to the Community Curated Lists section.

SocialClaw is an agent skill for Claude Code that enables scheduling and publishing social media posts across 13 platforms — X, LinkedIn (profile + page), Instagram (Business + standalone), Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest — through a single workspace API key.

- Install: `npx skills add ndesv21/socialclaw`
- Service: https://getsocialclaw.com
- License: MIT