### PR TITLE
Add YIELD INTELLIGENCE MCP server — Finance/Treasury data

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
 
+#### ⚡ MCP Servers
+
+- [YIELD INTELLIGENCE](https://github.com/thebrierfox/intuitek-ace) -  Passive income analysis MCP for Claude Desktop: live US Treasury rates, portfolio yield calculator, and AI income optimizer. No auth required, zero data retained.
+
 ---
 
 ## ⭐ Community Curated Lists


### PR DESCRIPTION
Adding YIELD INTELLIGENCE to the MCP Servers section.

What it does: Passive income opportunity analysis with live US Treasury rates, portfolio yield calculator, and AI-powered income optimization for Claude Desktop users.

Live MCP endpoint: https://api.intuitek.ai/yield/mcp (open, no auth required)

Install snippet:
```json
{"mcpServers": {"yield-intelligence": {"url": "https://api.intuitek.ai/yield/mcp"}}}
```

Tools: analyze_yield_opportunities, optimize_income_portfolio

No auth required, zero data retained, read-only financial data queries.

Also in the official MCP registry: io.github.thebrierfox/intuitek-ace
