### PR TITLE
Add daehounan/agency-agents-fork to Community Curated Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) -  Team of specialized AI agents for building features and debugging.
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) -  100+ specialized AI agents for full-stack development maintained by the community.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated list of Model Context Protocol (MCP) servers for extending Claude's capabilities.
+- [daehounan/agency-agents-fork](https://github.com/daehounan/agency-agents-fork#readme) -  163 specialist Claude Code agents + 24 routing skills bundled as a plugin. Korean / Japanese Business Navigators, game-dev routing (Unity / Unreal / Godot / Roblox / Blender), XR / spatial, paid-media, and skill-routing-arbitrator for disambiguating ~500 ecosystem skills.
 
 ---
 


### PR DESCRIPTION
Adds `daehounan/agency-agents-fork` to the `⭐ Community Curated Lists` section, following the pattern set by existing entries like `vijaythecoder/awesome-claude-agents` and `VoltAgent/awesome-claude-code-subagents` (which are agent collections, not awesome-lists per se).

## What this is

A Claude Code plugin bundle: 163 specialist agent personas + 24 routing skills + 16 NEXUS strategy playbooks, installable in one line. Fork of [msitarzewski/agency-agents](https://github.com/msitarzewski/agency-agents) with China-market agents excluded (22 files dropped) and Korean + Japanese Business Navigators added.

## Why "Community Curated Lists"

Same shelf as `vijaythecoder/awesome-claude-agents` ("Team of specialized AI agents") and `VoltAgent/awesome-claude-code-subagents` ("100+ specialized AI agents") — curated multi-agent collections that users install as a unit.

## Differentiators

- Korean Business Navigator and Japanese Business Navigator agents — decode 품의 / 稟議 / nunchi / 飲み会 / 報連相 / 名刺交換 / 결재라인 deal mechanics. No public equivalent.
- `skill-routing-arbitrator` meta-skill — disambiguates across ~500 skills in the wider Claude Code ecosystem (`ecc:*`, `anthropic-skills:*`, `engineering:*`, etc.)
- Cross-reference audit enforced in CI — 0 orphans across 180 backticked refs
- No outbound network calls (verified — see SECURITY.md)
- Does NOT require `--dangerously-skip-permissions`
- One-liner install: `claude --plugin-url <v1.2.0 release zip>`
- Scoped subsets available (`-engineering-finance`, `-marketing-paid-media-sales`, `-game-development`) for smaller token budgets
- MIT license

## Resource maturity

- Initial commits 2026-05-16, v1.2.0 release 2026-05-18
- 3 CI workflows green on every push (Lint Skills, audit-agent-refs, Build Plugin)
- Pending review at travisvn/awesome-claude-skills (PR #746, OPEN since 2026-05-18) and ComposioHQ/awesome-claude-skills (PR #894, `ready-to-merge` label applied 2026-05-22)
