### PR TITLE
Add usage to Applications/Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
-- [usage](https://github.com/aqua5230/usage) -  macOS menu bar app that pins Claude Code and Codex quota, token usage, and cost to your screen. Local-only with zero API calls.
+- [usage](https://github.com/aqua5230/usage) -  macOS menu bar and Windows tray app that pins Claude Code, Codex, and Antigravity quota, token usage, and cost to your screen. No LLM API calls.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [usage](https://github.com/aqua5230/usage) -  macOS menu bar app that pins Claude Code and Codex quota, token usage, and cost to your screen. Local-only with zero API calls.
 
 ---
 


### PR DESCRIPTION
Adds [usage](https://github.com/aqua5230/usage) under **💻 Applications → 🖥️ Desktop**.

**What it is:** a macOS menu bar app that pins Claude Code and Codex quota, token usage, and cost to your screen. It reads the usage data Claude Code and Codex leave locally, so it makes zero calls to the Anthropic/OpenAI APIs. Includes HTML reports, a TUI preview, multi-language UI, and multiple themes.

**Why it fits the list:** it is a Claude Code-focused application that fills a gap not covered by the existing Desktop entries (which are the official/Linux Claude desktop clients).

**Meets the contribution standards:**
- Open source — AGPL-3.0, public repo
- Actively maintained — regular releases, latest commits within days
- Clear docs — install via Homebrew or release download, usage instructions in README

Format used: `- [usage](https://github.com/aqua5230/usage) -  Description.` added to the bottom of the Desktop category.