### PR TITLE
Add Forward Deployed Selling — open-source Claude skill for enterprise AI sales

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) -  100+ specialized AI agents for full-stack development maintained by the community.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated list of Model Context Protocol (MCP) servers for extending Claude's capabilities.
 
+**Notable Community Skills**
+
+- [vonarmen-wq/forward-deployed-selling](https://github.com/vonarmen-wq/forward-deployed-selling) -  Open-source Claude skill for enterprise AI sales: ICP qualification, GTM strategy, stage diagnosis, and deal thesis generation. By Angel Armendariz (Principal, AWS).
+
 ---
 
 ## 🧩 Extensions & Integrations


### PR DESCRIPTION
## What

Adds [Forward Deployed Selling](https://github.com/vonarmen-wq/forward-deployed-selling) under a new **Notable Community Skills** subsection in the Community Curated Lists section.

## About the Skill

**Forward Deployed Selling** is a free, open-source Claude skill for enterprise B2B AI sales workflows:

- **ICP Qualification** — AI-driven scoring of Ideal Customer Profile fit
- **GTM Strategy** — Adaptive go-to-market strategy for complex enterprise deals
- **Stage Diagnosis** — Deal stage and health diagnostics
- **Deal Thesis Generation** — Structured deal narratives for internal alignment

Built by **Angel Armendariz**, Principal at AWS and enterprise AI strategist.  
Site: [forwarddeployedselling.com](https://forwarddeployedselling.com)

## Why It Fits

This repo curates the best of the Claude ecosystem. Forward Deployed Selling is a notable, purpose-built open-source Claude skill that represents a meaningful use case not currently in any curated Claude list — enterprise sales and GTM strategy. It's free, follows the Claude Skills format, and has a dedicated landing site.