### PR TITLE
docs: add claude-skills-cn to Community Curated Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) -  Team of specialized AI agents for building features and debugging.
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) -  100+ specialized AI agents for full-stack development maintained by the community.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated list of Model Context Protocol (MCP) servers for extending Claude's capabilities.
+- [fanshanhong/claude-skills-cn](https://github.com/fanshanhong/claude-skills-cn#readme) -  Chinese-language deep-dive library of 100+ Claude Code Skills (superpowers, oh-my-claudecode, ecc, gstack). Live site: [claudeskill.me](https://claudeskill.me).
 
 ---
 


### PR DESCRIPTION
Adding a Chinese-language curated list to complement the existing English-heavy resources in this section.

- Live: https://claudeskill.me  (104+ articles)
- Each entry: one Claude Code Skill, with use cases, internals, mermaid flowchart
- Source repo: https://github.com/fanshanhong/claude-skills-cn
- Content is AI-generated then human-audited (mermaid flowchart is a hard quality bar)

If the placement should be elsewhere (e.g. Educational Resources), happy to adjust.