### PR TITLE
Add restore-claude-history-linux to new Claude Code Community Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
 
+### 🧰 Claude Code Community Tools
+
+Community-maintained tools that extend or fix Claude Code itself.
+
+- [restore-claude-history-linux](https://github.com/vsits/restore-claude-history-linux) - Recover deleted Claude Code chat transcripts from Linux filesystem snapshots (ZFS / Btrfs / Timeshift). Linux port of garrettmoss/restore-claude-history.
+
 ### 🔌 Model Context Protocol (MCP)
 
 Open standard (Linux Foundation) for connecting Claude to tools, repos, databases, tickets, and more. Supports one-click desktop extensions (`.mcpb` files).


### PR DESCRIPTION
 Adds [vsits/restore-claude-history-linux](https://github.com/vsits/restore-claude-history-linux) under a new 🧰 **Claude Code Community Tools** subsection within the existing Claude Code section.

  The current Claude Code section lists only Anthropic-official resources, so this introduces a subsection per the contributing guide's invitation: *"New categories, or improvements to the existing categorization are welcome."* Community-maintained tools that extend or fix Claude Code itself belong adjacent to the official Claude Code entry, not under generic Extensions/Applications.

  ## About the tool

[vsits/restore-claude-history-linux](https://github.com/vsits/restore-claude-history-linux) recovers deleted Claude Code chat transcripts from Linux filesystem snapshots (ZFS, Btrfs, Timeshift). It's the Linux port of [garrettmoss/restore-claude-history](https://github.com/garrettmoss/restore-claude-history) (macOS Time Machine).
  
  ## Contribution requirements check
  
  - **Open source:** MIT license, public repo at [vsits/restore-claude-history-linux](https://github.com/vsits/restore-claude-history-linux)
  - **Actively maintained:** `v1.0.0` and `v1.1.0` shipped over the last few weeks
  - **Meaningful functionality:** pluggable backend abstraction with three shipped backends, full QEMU end-to-end test coverage on each
  - **Good documentation:** README covers install, every CLI flag, and a step-by-step recovery walkthrough
  - **Entry format:** matches the contributing guide's exact spec — `- [Project Name](link) - Description.` with capital first letter and period
