### PR TITLE
Add claude-code-cache-fix to Claude Code Community Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
 
+### 🧰 Claude Code Community Tools
+
+Community-maintained tools that extend or fix Claude Code itself.
+
+- [restore-claude-history-linux](https://github.com/vsits/restore-claude-history-linux) - Recover deleted Claude Code chat transcripts from Linux filesystem snapshots (ZFS / Btrfs / Timeshift). Linux port of garrettmoss/restore-claude-history.
+
 ### 🔌 Model Context Protocol (MCP)
 
 Open standard (Linux Foundation) for connecting Claude to tools, repos, databases, tickets, and more. Supports one-click desktop extensions (`.mcpb` files).

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 Community-maintained tools that extend or fix Claude Code itself.
 
 - [restore-claude-history-linux](https://github.com/vsits/restore-claude-history-linux) - Recover deleted Claude Code chat transcripts from Linux filesystem snapshots (ZFS / Btrfs / Timeshift). Linux port of garrettmoss/restore-claude-history.
+- [claude-code-cache-fix](https://github.com/cnighswonger/claude-code-cache-fix) - Local proxy that fixes Claude Code's prompt-cache TTL handling, reducing token spend on long sessions.
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
  Adds [`cnighswonger/claude-code-cache-fix`](https://github.com/cnighswonger/claude-code-cache-fix) to the **🧰 Claude Code Community Tools** subsection.

  > **Note on PR stacking:** This PR is branched off of #250 (the `restore-claude-history-linux` PR that introduces the new subsection). If you merge #250 first, this PR's diff against `main` will collapse to just the +1 line for cache-fix. If you
  prefer to review them independently, the cache-fix-specific change is a single bullet inside the subsection already established by #250.

  ## About the tool

  [`cnighswonger/claude-code-cache-fix`](https://github.com/cnighswonger/claude-code-cache-fix) is a local proxy that fixes Claude Code's prompt-cache TTL handling, reducing token spend on long sessions. Runs as a drop-in shim via `npx
  claude-code-cache-fix`.

  ## Contribution requirements check

  - **Open source:** MIT license, public repo at [cnighswonger/claude-code-cache-fix](https://github.com/cnighswonger/claude-code-cache-fix)
  - **Actively maintained:** multiple releases shipped, npm package published and updated
  - **Meaningful functionality:** HTTP proxy with cache-TTL correction logic, ships with documentation of the cache behavior it fixes
  - **Good documentation:** README covers install (`npx`), config, and observed cache-hit-rate improvements
  - **Entry format:** matches the contributing guide's exact spec — `- [Project Name](link) - Description.` with capital first letter and period.
