### PR TITLE
Add markupmarkdown to Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 ### 📝 Collaboration & Writing
 
-- [markupmarkdown](https://github.com/jonradoff/markupmarkdown) -  Google-Docs-style commenting on any markdown file, with an MCP server so Claude joins the same review loop as humans. Paste a GitHub URL (or upload), drag-select text → leave a thread, @-mention humans, resolve, then call `revise_with_ai` to have Claude apply the resolved comments as a new revision. Self-hosted, MIT, live demo at <https://mumd.metavert.io/>.
+- [markupmarkdown](https://github.com/jonradoff/markupmarkdown) - "Google Docs for Markdown": collaborative editing and review for `.md` files, with an MCP server so Claude joins the same review loop as humans. Claude can comment, propose suggested changes (one-click apply), request changes, and draft revisions that a human accepts before they push back to GitHub as a PR. Self-hosted, MIT, live demo at <https://mumd.metavert.io/>.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### 📝 Collaboration & Writing
+
+- [markupmarkdown](https://github.com/jonradoff/markupmarkdown) -  Google-Docs-style commenting on any markdown file, with an MCP server so Claude joins the same review loop as humans. Paste a GitHub URL (or upload), drag-select text → leave a thread, @-mention humans, resolve, then call `revise_with_ai` to have Claude apply the resolved comments as a new revision. Self-hosted, MIT, live demo at <https://mumd.metavert.io/>.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
Adds [markupmarkdown](https://github.com/jonradoff/markupmarkdown) under **Applications → Collaboration & Writing** (new subsection).

## What it is

Google-Docs-style commenting on any markdown file, with first-class agent collaboration. Humans and agents leave threaded comments anchored to text spans on the same documents. AI revision is powered by Claude Opus 4.7 — call `revise_with_ai` on a doc whose comments you've resolved, and Claude produces a new revision applying that feedback while minimally touching unrelated content. Streams the rewrite as rendered markdown in real time.

The MCP server at `/mcp` exposes the full review surface (`list_documents`, `get_document`, `list_comments`, `add_comment`, `reply`, `resolve_comment`, `revise_with_ai`) so Claude (Code, Desktop, Agent SDK apps, custom MCP clients) can join the same review loop as humans — see comments humans left, reply, resolve, and trigger revisions with explicit human sign-off.

**Live demo:** <https://mumd.metavert.io/>

## Why it fits this list

- Anthropic API integration is core to the product (AI revision)
- Bundles an MCP server with `@mark3labs/mcp-go`
- BYOK Anthropic key (encrypted at rest via AES-256-GCM)
- Self-hosted, open source (MIT), one Go binary + React SPA + MongoDB
- Active development; complete docs in README + `SKILL.md` (the agent guide)

## Checklist

- [x] Open source (MIT) with public repo
- [x] Actively maintained (commits this week)
- [x] Meaningful functionality beyond examples (full review tool)
- [x] Good documentation (README + SKILL.md served at `/SKILL.md`)
- [x] Format matches surrounding entries
- [x] One PR for one suggestion