### PR TITLE
Add Threadminder — persistent context MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [pluralityworks/threadminder-mcp](https://github.com/pluralityworks/threadminder-mcp) -  Persistent context for Claude. Your AI always knows where your projects stand, what's in progress, and what's next — across every session. Remote hosted, OAuth auth.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [Threadminder](https://github.com/pluralityworks/threadminder-mcp) to the MCP section.

Threadminder gives your AI persistent context across every chat and session, so your AI always knows what's going on - where your projects stand, what's in progress, and what's next. No re-explaining. No starting from scratch. Just open Claude and keep going.

- Remote hosted, OAuth auth
- MCP URL: `mcp.threadminder.ai/mcp`
- Homepage: https://threadminder.ai
- Categories: Memory, Productivity, Project Management

🤖 Generated with [Claude Code](https://claude.com/claude-code)