### PR TITLE
Add TWZRD Agent Intel MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 ### ⚡ MCP Servers
 
-- **[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final)** - Solana-native AI agent trust scoring via x402 micropayments. Free on-chain preflight + paid signed V5 trust receipts in <1s. Live MCP endpoint: `https://intel.twzrd.xyz/mcp`
+- **[TWZRD Agent Intel](https://intel.twzrd.xyz)** - Solana-native AI agent trust scoring via x402 micropayments. Free on-chain preflight + paid signed V5 trust receipts in <1s. Live MCP endpoint: `https://intel.twzrd.xyz/mcp`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### ⚡ MCP Servers
+
+- **[TWZRD Agent Intel](https://github.com/twzrd-sol/wzrd-final)** - Solana-native AI agent trust scoring via x402 micropayments. Free on-chain preflight + paid signed V5 trust receipts in <1s. Live MCP endpoint: `https://intel.twzrd.xyz/mcp`
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
## Summary

- Adds **TWZRD Agent Intel** under a new `### ⚡ MCP Servers` subsection in **Extensions & Integrations**
- TWZRD Agent Intel is a Solana-native AI agent trust scoring service accessible via a live Streamable-HTTP MCP endpoint (`https://intel.twzrd.xyz/mcp`)
- Uses the x402 micropayment protocol (HTTP 402, USDC on Solana): free on-chain preflight checks + paid signed V5 trust receipts settled in <1s

## Entry added

```
- **[TWZRD Agent Intel](https://intel.twzrd.xyz)** - Solana-native AI agent trust scoring via x402 micropayments. Free on-chain preflight + paid signed V5 trust receipts in <1s. Live MCP endpoint: `https://intel.twzrd.xyz/mcp`
```

## Why it belongs here

The MCP section already links to `punkpeye/awesome-mcp-servers` for discovery, but there's no place in this list for individual MCP servers that are notable integrations. TWZRD Agent Intel is a production MCP server that Claude Code and other MCP-compatible agents can connect to directly for on-chain trust data — a natural fit under Extensions & Integrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)