### PR TITLE
Add codebase-memory-mcp to the MCP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [DeusData/codebase-memory-mcp](https://github.com/DeusData/codebase-memory-mcp#readme) -  Code-intelligence MCP server that indexes a codebase into a queryable knowledge graph (functions, classes, call chains, routes) — 159 languages, sub-ms structural queries, ~99% fewer tokens than grep. Single static binary, 100% local.
 
 ---
 


### PR DESCRIPTION
Adds **codebase-memory-mcp** to the Model Context Protocol (MCP) section.

- **Repo:** https://github.com/DeusData/codebase-memory-mcp (MIT, single static binary)
- **What it is:** a code-intelligence MCP server that indexes a codebase into a persistent, queryable knowledge graph (functions, classes, call chains, HTTP routes, cross-service links) for Claude Code and other agents — 159 languages via tree-sitter + Hybrid LSP, sub-ms structural queries, ~99% fewer tokens than file-by-file grep. 14 MCP tools.
- **Why include it:** purpose-built for Claude Code (it ships a one-command installer that auto-configures Claude Code's MCP entry, instructions, and hooks), zero dependencies, no API keys, 100% local. macOS/Linux/Windows.

Placed in the MCP subsection next to the community server list. Happy to move it if you'd prefer a different section.