### PR TITLE
feat: add The Stall — 210 pay-per-call MCP tools (x402, v4.64.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
 
+#### ⚡ MCP Servers
+
+- [The Stall](https://the-stall.intuitek.ai/mcp) - 172 pay-per-call financial and market intelligence tools (x402 USDC micropayments, no API key). Equities, crypto/DeFi, macro, on-chain analytics, options, and 20+ verticals. Remote MCP — paste URL into Claude Desktop or any MCP client.
+
 ---
 
 ## ⭐ Community Curated Lists


### PR DESCRIPTION
## The Stall

Adds **The Stall** to the MCP section as a featured MCP server.

### What it is
A remote MCP server with 210 pay-per-call financial and market intelligence tools. No install required — paste the URL into Claude Desktop or any MCP client.

### Coverage
- **Equities:** stock price, fundamentals, earnings surprises, analyst ratings, insider trades, options chain
- **Crypto/DeFi:** prices, DEX swap quotes, whale radar, protocol revenue, stablecoin watch
- **Macro:** FOMC tracker, treasury yields, IMF outlook, economic calendar
- **On-chain:** EVM logs, wallet balance, ERC-20 snapshots, token security, ENS lookup
- **Alternative data:** congressional trades, OFAC sanctions screening, Polymarket accuracy
- 20+ more verticals

### Payment
x402 protocol — USDC micropayments on Base, sub-cent per call. No API key or subscription required.

**MCP URL:** `https://the-stall.intuitek.ai/mcp`
