### PR TITLE
Add Cate to Applications > Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [Cate](https://github.com/0-AI-UG/cate#readme) - Open source desktop IDE on an infinite zoomable canvas with built-in Claude Code agent panels. Arrange editors, terminals, and browsers in spatial workspaces instead of tabs. macOS, Windows, Linux. 1.3k+ stars.
 
 ---
 


### PR DESCRIPTION
This adds Cate (https://github.com/0-AI-UG/cate), an open source desktop IDE built on an infinite zoomable canvas with built-in Claude Code agent panels. It fits the Desktop applications category: MIT licensed, actively developed, cross-platform (macOS, Windows, Linux), documented, and at about 1.3k stars. Website: https://cate.cero-ai.com
