### PR TITLE
Add Headroom — macOS menu bar companion for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [Headroom](https://github.com/patwalls/headroom#readme) - Native macOS menu bar app showing Claude Code's 5-hour session and 7-day weekly usage as a live percentage. Zero network calls — reads the local file Claude Code writes. ([site](https://headroom.walls.sh))
 
 ---
 


### PR DESCRIPTION
## What
Adds [Headroom](https://github.com/patwalls/headroom) to the Applications > Desktop section.

## Why
Headroom is a native macOS menu bar app that shows Claude Code's 5-hour session and 7-day weekly utilization as a live percentage, with color-coded alerts as limits approach. It reads the local file Claude Code writes via a statusline hook — zero network calls, zero configuration.

- Free, MIT, signed & notarized
- Install: `brew install --cask patwalls/tap/headroom` or download from https://headroom.walls.sh
- GitHub: https://github.com/patwalls/headroom (267 lines of Swift)