### PR TITLE
Update current models to Fable 5 and Opus 4.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,21 @@ AI assistant by Anthropic for complex reasoning, code generation, and analysis t
 
 **The authoritative source for everything Claude -  directly from Anthropic**
 
-### 🧠 Current Models (Claude 4.7 Family - 2026)
+### 🧠 Current Models (2026)
 
-- **Claude Opus 4.7** (Apr 16, 2026) -  Anthropic's latest and most capable model. Major gains on the hardest software engineering tasks (13% resolution improvement over Opus 4.6 on a 93-task coding benchmark, 3x more production task resolutions on engineering benchmarks). Substantially better vision (images up to ~3.75 MP / 2,576px long edge, 98.5% visual acuity on computer-use tasks vs. 54.5% for Opus 4.6), 21% fewer document-reasoning errors, stronger long-running agentic workflows, and improved file-system memory across sessions. New: `xhigh` effort level, task budgets (public beta), `/ultrareview` slash command, extended auto mode for Max users. Same price as Opus 4.6. [Announcement](https://www.anthropic.com/news/claude-opus-4-7) | [What's new](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-7) | [System Card](https://www.anthropic.com/claude-opus-4-7-system-card)
-- **Claude Opus 4.6** (Feb 5, 2026) -  Previous Opus generation. Best-in-class for coding, long-horizon agents, large codebases, debugging, financial analysis, and enterprise workflows. Introduced 1M token context window (beta), adaptive thinking (dynamic reasoning depth), agent teams, context compaction. SOTA on Terminal-Bench 2.0, GDPval-AA (+190 Elo over Opus 4.5), Humanity's Last Exam, BrowseComp. [Announcement](https://www.anthropic.com/news/claude-opus-4-6) | [System Card](https://www.anthropic.com/claude-opus-4-6-system-card)
+- **Claude Fable 5** (Jun 9, 2026) -  Anthropic's most capable widely released model, for the most demanding reasoning and long-horizon agentic work. State-of-the-art on nearly all tested benchmarks — software engineering, knowledge work, vision, and scientific research — with its lead growing on longer, more complex tasks (highest score on Cognition's FrontierBench, first model past 90% on Anthropic's core long-running analytics benchmark, strongest finance model Anthropic has tested). Thinking is always on; the raw chain of thought is never returned. Safety classifiers route high-risk requests (cybersecurity, bio/chem, model distillation — under 5% of sessions) to Opus 4.8. Requires 30-day data retention (not available under zero data retention). **Claude Mythos 5** is the same underlying model with safeguards lifted for authorized users (Project Glasswing). [Announcement](https://www.anthropic.com/news/claude-fable-5-mythos-5) | [Docs](https://platform.claude.com/docs/en/about-claude/models/introducing-claude-fable-5-and-claude-mythos-5) | [System Card](https://www.anthropic.com/claude-fable-5-mythos-5-system-card)
+- **Claude Opus 4.8** (May 28, 2026) -  Anthropic's current flagship Opus — highly autonomous, state-of-the-art on long-horizon agentic work, knowledge work, and memory, with clearer and warmer writing. Gains across coding, agentic reasoning, and analysis over Opus 4.7; early testers found it ~4x less likely to leave flaws in its own code unremarked. New: **Dynamic Workflows** in Claude Code (research preview — plan work, run hundreds of parallel subagents in one session, verify before returning, enabling codebase-scale migrations), effort control on claude.ai, and mid-conversation system messages via the Messages API. Same price as Opus 4.7. [Announcement](https://www.anthropic.com/news/claude-opus-4-8) | [What's new](https://platform.claude.com/docs/en/about-claude/models/whats-new-claude-4-8) | [System Card](https://www.anthropic.com/claude-opus-4-8-system-card)
+- **Claude Opus 4.7** (Apr 16, 2026) -  Previous-generation Opus. Highly autonomous, with strong long-horizon agentic work, knowledge work, vision (images up to ~3.75 MP / 2,576px long edge), and file-system memory across sessions. Introduced the `xhigh` effort level and task budgets (beta). [Announcement](https://www.anthropic.com/news/claude-opus-4-7) | [System Card](https://www.anthropic.com/claude-opus-4-7-system-card)
 - **Claude Sonnet 4.6** (Feb 17, 2026) -  Best balance of intelligence, speed, and cost. Near-Opus performance on coding, computer use (multi-tab forms, spreadsheets), and professional tasks. Default model for many plans. [Announcement](https://www.anthropic.com/news/claude-sonnet-4-6)
 - **Claude Haiku 4.5** (Oct 2025) -  Fastest model with near-frontier intelligence. Perfect for high-volume, real-time, and sub-agent tasks. [Announcement](https://www.anthropic.com/news/claude-haiku-4-5)
 
 **Key specs (API):**  
-- Opus 4.7: `claude-opus-4-7` • $5/$25 per MTok • 200K standard / 1M beta context  
-- Opus 4.6: `claude-opus-4-6` • $5/$25 per MTok • 200K standard / 1M beta context  
-- Sonnet 4.6: `claude-sonnet-4-6` • $3/$15 per MTok • 200K standard / 1M beta context  
-- Haiku 4.5: `claude-haiku-4-5` • $1/$5 per MTok • 200K context  
-Premium pricing for >200K tokens. Full comparison: [Models overview](https://platform.claude.com/docs/en/about-claude/models/overview)
+- Fable 5: `claude-fable-5` • $10/$50 per MTok • 1M context / 128K max output  
+- Opus 4.8: `claude-opus-4-8` • $5/$25 per MTok • 1M context / 128K max output  
+- Opus 4.7: `claude-opus-4-7` • $5/$25 per MTok • 1M context / 128K max output  
+- Sonnet 4.6: `claude-sonnet-4-6` • $3/$15 per MTok • 1M context / 64K max output  
+- Haiku 4.5: `claude-haiku-4-5` • $1/$5 per MTok • 200K context / 64K max output  
+Full comparison: [Models overview](https://platform.claude.com/docs/en/about-claude/models/overview)
 
 ### 🔌 API & Developer Platform
 
@@ -77,9 +79,9 @@ Premium pricing for >200K tokens. Full comparison: [Models overview](https://pla
 
 ### ☁️ Cloud Providers
 
-**Official access to Claude models through cloud providers** (all support Opus 4.7 / Opus 4.6 / Sonnet 4.6)
+**Official access to Claude models through cloud providers** (all support Opus 4.8 / Opus 4.7 / Sonnet 4.6)
 
-- **[Amazon Bedrock](https://aws.amazon.com/bedrock/anthropic/)** -  Fully managed access to the latest Claude models (Opus 4.7, Opus 4.6, Sonnet 4.6, Haiku 4.5). Supports cross-region inference (new regions: Thailand, Malaysia, Singapore, Indonesia, Taiwan), latency optimizations, fine-tuning, agents, guardrails, and deep AWS integration.
+- **[Amazon Bedrock](https://aws.amazon.com/bedrock/anthropic/)** -  Fully managed access to the latest Claude models (Opus 4.8, Opus 4.7, Sonnet 4.6, Haiku 4.5). Supports cross-region inference, latency optimizations, fine-tuning, agents, guardrails, and deep AWS integration. (Note: Managed Agents and Anthropic server-side tools are not available on Bedrock — use Claude API + tool use there.)
 - **[Google Cloud Vertex AI Model Garden](https://cloud.google.com/products/model-garden/claude)** -  Deploy Claude models with provisioned throughput, prompt caching, batch predictions, grounding, and enterprise compliance (FedRAMP High). Great for building agents with Google Cloud tools.
 - **[Microsoft Azure AI Model Catalog (Anthropic Publisher)](https://ai.azure.com/catalog/publishers/anthropic)** -  Claude models via the AI Model Catalog. Supports serverless deployment, agent building, tool integration, fine-tuning, and billing through existing Azure agreements.
 
@@ -89,6 +91,8 @@ Premium pricing for >200K tokens. Full comparison: [Models overview](https://pla
 
 - [Transparency Hub](https://www.anthropic.com/transparency) -  Overview of safety evaluations and improvements across models.
 - [All System Cards](https://www.anthropic.com/system-cards) -  Index of all model system cards.
+  - [Claude Fable 5 & Mythos 5 System Card](https://www.anthropic.com/claude-fable-5-mythos-5-system-card) -  Capability and safety report (Jun 2026).
+  - [Claude Opus 4.8 System Card](https://www.anthropic.com/claude-opus-4-8-system-card) -  Capability and safety report (May 2026).
   - [Claude Opus 4.7 System Card](https://www.anthropic.com/claude-opus-4-7-system-card) -  Capability and safety report (Apr 2026).
   - [Claude Opus 4.6 System Card](https://www.anthropic.com/claude-opus-4-6-system-card) -  Capability and safety report (Feb 2026).
   - [Claude Sonnet 4.6 System Card](https://www.anthropic.com/claude-sonnet-4-6-system-card) -  Detailed evaluations (Feb 2026).


### PR DESCRIPTION
Refreshes the outdated model lineup (was headed "Claude 4.7 Family").

- Add **Claude Fable 5 / Mythos 5** (Jun 9, 2026) as most-capable widely-released model
- Add **Claude Opus 4.8** (May 28, 2026) as current flagship Opus
- Demote Opus 4.7 to previous-generation; drop 4.6 from headline list
- Correct key specs to 1M context + accurate max-output figures
- Update cloud provider supported-model line; add Bedrock caveat
- Add Fable 5 and Opus 4.8 system card links

All links and dates verified against live Anthropic pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)