### PR TITLE
Add Prismix MCP Directory to MCP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [Prismix MCP Directory](https://prismix.dev/mcp) -  Aggregator with 500+ auto-discovered MCP servers (GitHub topic search) + 80+ curated servers. Features bundles (reusable server sets for Claude Desktop), per-server release tracking, and search. Complements awesome-mcp-servers with a live web UI.
 
 ---
 


### PR DESCRIPTION
## What

Adds [Prismix MCP Directory](https://prismix.dev/mcp) to the **Model Context Protocol (MCP)** section, right after the `punkpeye/awesome-mcp-servers` entry.

## About Prismix MCP Directory

Prismix is a live MCP server aggregator that complements awesome-mcp-servers with a web UI and additional discovery:

- **500+ auto-discovered servers** via GitHub topic search (`mcp`, `model-context-protocol`)
- **80+ curated servers** (hand-vetted, with install instructions)
- **Bundles** — reusable server sets for Claude Desktop (e.g., "Best for coding", "Web scraping stack")
- **Per-server release tracking** with Atom RSS feed
- **Search by category** (coding, databases, data/files, browser automation, productivity, etc.)

The `/mcp` directory is the dedicated MCP section of the Prismix AI hub.

Live: https://prismix.dev/mcp