### PR TITLE
feat: add CreatorSkills to Applications > Skill Marketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### 🛍️ Skill Marketplaces
+
+- [CreatorSkills](https://creatorskills.co) -  Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, and audience growth. Works with Claude and ChatGPT.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
## Summary

Adds [CreatorSkills](https://creatorskills.co) under a new **🛍️ Skill Marketplaces** subsection in the Applications section.

CreatorSkills is a marketplace of 30+ downloadable AI skills (SKILL.md format) for content creators — covering YouTube scripting, sponsorship analysis, and audience growth. Skills work directly with Claude and ChatGPT.

## Why it fits

- Skills are packaged as SKILL.md files, compatible with Claude Code and Claude.ai
- Fills a gap: no skill marketplace was previously listed in this resource
- Directly relevant to Claude users looking for pre-built, downloadable skill packages for their workflows