### PR TITLE
Add sneg55/agent-starter to Community Curated Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) -  Team of specialized AI agents for building features and debugging.
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) -  100+ specialized AI agents for full-stack development maintained by the community.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated list of Model Context Protocol (MCP) servers for extending Claude's capabilities.
+- [sneg55/agent-starter](https://github.com/sneg55/agent-starter#readme) -  Skills, hooks, templates, and guides for bootstrapping AI-agent-friendly projects, with a per-project self-improvement loop.
 
 ---
 


### PR DESCRIPTION
Adds [sneg55/agent-starter](https://github.com/sneg55/agent-starter) under **⭐ Community Curated Lists**.

It's a curated collection of Claude Code skills, hooks, templates, and engineering guides for bootstrapping AI-agent-friendly projects — including a per-project self-improvement loop that turns usage signal into better project rules over time. Open source (MIT), actively maintained, with clear install/usage docs.

Entry follows the required format: `- [Name](URL) - Description.`, added to the bottom of the relevant category.