### PR TITLE
Added claudectl

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) -  Team of specialized AI agents for building features and debugging.
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) -  100+ specialized AI agents for full-stack development maintained by the community.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated list of Model Context Protocol (MCP) servers for extending Claude's capabilities.
+- [babarmuhammad/claudectl⁠](https://github.com/babarmuhammad/claudectl#readme)￼ - Terminal-based orchestration tool for Claude Code that enables multi-session control, live monitoring, cost tracking, and automated workflow rules for AI agents.
 
 ---
 


### PR DESCRIPTION
claudectl is a workspace and project-memory layer for Claude Code.  It automatically generates and maintains CLAUDE.md files, builds project memory from repositories, Git history, codebases, and previous Claude sessions, discovers and documents MCP servers, manages prompts and workflows, and helps developers work across multiple Claude Code projects from a single interface.  The goal is to turn Claude Code from a collection of chats into a persistent development workspace that remembers your projects, tools, documentation, and workflows.