### PR TITLE
Add OpenClacky to Applications — open-source Claude Code alternative with 93.8% cache efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [OpenClacky](https://openclacky.com) -  Open-source AI coding agent and Claude Code alternative (MIT). Achieves **93.8% Prompt Cache hit rate** and ~0.8× API cost via frozen 16-tool schema and Insert-then-Compress context management. BYOK: Claude, GPT-4, DeepSeek, Gemini, OpenRouter. [GitHub](https://github.com/clacky-ai/open-clacky)
 
 ---
 


### PR DESCRIPTION
## What's being added

[OpenClacky](https://openclacky.com) — added to the **Desktop Applications** section as an open-source Claude Code alternative.

GitHub: https://github.com/clacky-ai/open-clacky

## Why it belongs here

The Applications > Desktop section lists tools that use Claude as their underlying model. OpenClacky is an open-source, self-hosted AI coding agent built on top of Claude (and other LLMs), making it a natural fit alongside Claude Desktop and similar apps.

Key differentiator: **93.8% Prompt Cache hit rate** and **~0.8x API cost vs Claude Code** — via frozen 16-tool schema, dual cache markers, and Insert-then-Compress context management.

**BYOK**: Claude, GPT-4, DeepSeek, Gemini, OpenRouter (any OpenAI-compatible endpoint)
**License**: MIT
**Website**: https://openclacky.com