### PR TITLE
add presentation design prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [travisvn/awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills#readme) -  Resources and tools for customizing AI workflows with Claude Skills.
 - [BehiSecc/awesome-claude-skills](https://github.com/BehiSecc/awesome-claude-skills#readme) -  Categorized skills for document handling, development tools, data analysis, and more.
 - [langgptai/awesome-claude-prompts](https://github.com/langgptai/awesome-claude-prompts#readme) -  Collection of prompt examples designed to improve Claude interactions.
+- [SlideSpeak/presentation-design-prompts](https://github.com/SlideSpeak/presentation-design-prompts#readme) -  56 slide-design prompts for Claude, each a full deck theme with a pinned color palette, fonts, and layout rules.
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) -  Team of specialized AI agents for building features and debugging.
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) -  100+ specialized AI agents for full-stack development maintained by the community.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated list of Model Context Protocol (MCP) servers for extending Claude's capabilities.


### PR DESCRIPTION
I maintain an open-source collection of slide-design prompts that works well with Claude, so I added it to Community Curated Lists next to the other prompt collections.

Each entry is one prompt carrying a full design system: a color palette pinned to hex values, named Google Fonts, and layout rules. Paste it into Claude, say what the talk covers, and the slides come out consistent. 56 themes, MIT licensed.

Repo: https://github.com/SlideSpeak/presentation-design-prompts

Happy to reword the entry if the description is too long. Thanks for considering it.
