### PR TITLE
Update Agent Island for 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
-- [Agent Island](https://github.com/tristan666666/agent-island) -  Open-source macOS notch companion for Claude Code and Codex long runs, with live session state, usage tracking, and optional auto-resume for a selected task.
+- [Agent Island](https://github.com/tristan666666/agent-island) -  Open-source status companion for Claude Code and Codex with live session state, your-turn alerts, and local monitoring on macOS and Windows.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
-- [Agent Island](https://github.com/tristan666666/agent-island) -  Free, MIT-licensed native companion for Claude, Codex, Antigravity, Grok, and Cursor with local session status, your-turn alerts, and provider usage views.
+- [Agent Island](https://github.com/tristan666666/agent-island) - Free, MIT-licensed native companion for Claude, Codex, Antigravity, Grok, and Cursor with local session status, your-turn alerts, and provider usage views.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [Agent Island](https://github.com/tristan666666/agent-island) -  Open-source macOS notch companion for Claude Code and Codex long runs, with live session state, usage tracking, and optional auto-resume for a selected task.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
-- [Agent Island](https://github.com/tristan666666/agent-island) -  Open-source status companion for Claude Code and Codex with live session state, your-turn alerts, and local monitoring on macOS and Windows.
+- [Agent Island](https://github.com/tristan666666/agent-island) -  Free, MIT-licensed native companion for Claude, Codex, Gemini, Grok, and Cursor with local session status, your-turn alerts, and provider usage views.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
-- [Agent Island](https://github.com/tristan666666/agent-island) -  Free, MIT-licensed native companion for Claude, Codex, Gemini, Grok, and Cursor with local session status, your-turn alerts, and provider usage views.
+- [Agent Island](https://github.com/tristan666666/agent-island) -  Free, MIT-licensed native companion for Claude, Codex, Antigravity, Grok, and Cursor with local session status, your-turn alerts, and provider usage views.
 
 ---
 


### PR DESCRIPTION
## Summary

Refreshes the existing Agent Island desktop-app entry for [https://github.com/tristan666666/agent-island/releases/tag/2.1.2](https://github.com/tristan666666/agent-island/releases/tag/2.1.2) with current support for Claude, Codex, Antigravity, Grok, and Cursor, plus local session status, your-turn alerts, and provider usage views.

I maintain Agent Island. The project is free, MIT licensed, actively maintained, and publicly documented. This is a factual update to the original PR.