### PR TITLE
Add NotFair — open-source SEO & paid-ads skills for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
+- [nowork-studio/NotFair](https://github.com/nowork-studio/NotFair) -  Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads (~2.9k stars, MIT). Connects to live marketing data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP to run audits, keyword research, schema markup, and paid-ads optimizations directly from Claude Code.
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
Thanks for maintaining this list — it's become a genuinely useful reference for the Claude ecosystem.

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)**, an open-source (MIT) set of Claude Code skills for marketing work. It covers SEO/GEO, Google Ads, and Meta Ads — roughly 30 skills organized in `seo/`, `google-ads/`, and `meta-ads/` folders. It connects to live data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP, so Claude Code can pull real account data, run audits, and apply changes directly.

It has ~2.9k stars and is actively maintained. I've placed it at the bottom of the **Claude Code** subsection, which felt like the most natural home given it's a Claude Code plugin rather than a standalone MCP server.

Happy to reword, move to a different section, or trim the description if you'd prefer something shorter.