### PR TITLE
Add Publish to dochost to Browser Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
+- [Publish to dochost](https://chromewebstore.google.com/detail/publish-to-dochost/ihnogobgkjojleeiajngmcdlaccjdmdi) -  Publish Claude-generated HTML or Markdown to a permanent shareable link in one click.
 
 ---
 


### PR DESCRIPTION
Adds **Publish to dochost** under Extensions & Integrations → Browser Extensions — a Chrome extension that publishes Claude-generated HTML/Markdown to a permanent shareable link in one click.

Matches the existing entry format and links to the Chrome Web Store listing.

Chrome Web Store: https://chromewebstore.google.com/detail/publish-to-dochost/ihnogobgkjojleeiajngmcdlaccjdmdi