### PR TITLE
feat: add EGC - persistent memory MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [EGC](https://github.com/Fmarzochi/EGC) -  Persistent cross-session memory for Claude Code and 12 other AI coding tools. SQLite-backed, install with `npm install -g @egchq/egc`.
 
 ---
 


### PR DESCRIPTION
Adds [EGC](https://github.com/Fmarzochi/EGC) to the Model Context Protocol (MCP) section.

EGC is a persistent cross-session memory MCP server for Claude Code and 12 other AI coding tools. SQLite-backed state survives context resets and keeps all tools in sync.

- GitHub: https://github.com/Fmarzochi/EGC
- npm: `npm install -g @egchq/egc`
- License: MIT