### PR TITLE
Add open-bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
+- [open-bridge](https://github.com/bks-lab/open-bridge#readme) -  Agent-agnostic operating manual in plain Markdown + YAML that your coding agent reads each session — your repos, clients, and a plain-text task board/log (backlog→doing→review→done). One skills/ tree across Claude Code, Codex, Copilot CLI. MIT.
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
Adds **open-bridge** — an open-source, agent-agnostic "operating manual" for AI coding agents: a plain git repo of Markdown + YAML the agent reads at the start of every session, so it begins each session already knowing your repos, clients, and task conventions. One `skills/` tree works across Claude Code, Codex, and Copilot CLI.

I placed it at the end of the **Claude Code** section, but it's a third-party/community tool rather than an official resource — please move it to wherever fits best (or tell me and I'll adjust the placement).

Honest scope: one self-hosted instance so far, no external users yet — it documents the method/substrate, not adoption. MIT (separate trademark policy). Repo: https://github.com/bks-lab/open-bridge