### PR TITLE
Add AI School — free Claude API & prompt engineering courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [40+ Claude Code Tips](https://github.com/ykdojo/claude-code-tips#readme) -  Tips for getting the most out of Claude Code, including a custom status line script, cutting the system prompt in half, using Gemini CLI as Claude Code's minion, and Claude Code running itself in a container. Also includes the dx plugin for GitHub Actions debugging, conversation cloning, and handoffs.
 - [My Experience With Claude Code After 2 Weeks of Adventures](https://sankalp.bearblog.dev/my-claude-code-experience-after-2-weeks-of-usage/) - Part 1: Real-world lessons on using a `TODO.md` file to keep Claude on track, managing costs, and why it often outperforms Cursor for complex refactors.
 - [A Guide to Claude Code 2.0 and getting better at using coding agents](https://sankalp.bearblog.dev/my-experience-with-claude-code-20-and-how-to-get-better-at-using-coding-agents/#setup) - Part 2: A deep dive into the 2.0 update, focusing on the "Agent Manager" mindset, context engineering, and using sub-agents for larger codebases.
+- [AI School — Claude API & Prompt Engineering Courses](https://lillytechsystems.com/ai-school/claude/) - Free courses covering Claude API pricing with live cost calculator, production prompt engineering, and token optimization; no signup required.
 
 ---
 


### PR DESCRIPTION
## What this adds

A free educational platform entry to the **Community Guides** section under Educational Resources:

```
- [AI School — Claude API & Prompt Engineering Courses](https://lillytechsystems.com/ai-school/claude/)
  Free courses covering Claude API pricing with live cost calculator, production prompt engineering,
  and token optimization; no signup required.
```

## Why it fits

AI School's Claude hub (`/ai-school/claude/`) covers:
- **Claude API Costs** — real pricing breakdown with a live calculator (Jun 2026 rates)
- **Prompt Patterns in Production** — 4 failure vectors, structured prompt engineering
- **Token Optimization** — reduce costs without sacrificing output quality

All courses are free, no signup, and link back to the canonical source. Actively maintained (commits weekly). Source: https://github.com/Lilly-Tech-Collab/AI-School