### PR TITLE
Add inite-brain-service

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Full comparison: [Models overview](https://platform.claude.com/docs/en/about-cla
 
 **Anthropic's agentic coding platform and open extension standard**
 
+- [inite-brain-service](https://github.com/inite-ai/inite-brain-service) — open-source memory layer for Claude (and any other MCP client). Bitemporal knowledge graph, 18 tools, three memory tiers (facts/episodes/procedural), conflict resolution, GDPR forget. AGPL-3.0.
 ### 🤖 Claude Code
 
 Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integrations, Desktop GUI (Cowork), and browser control. Understands entire codebases, plans and executes multi-step tasks, edits files, runs git/shell, creates PRs, and integrates browser control.


### PR DESCRIPTION
Adds inite-brain-service — open-source (AGPL-3.0) bitemporal memory layer for LLM agents. MCP server (Streamable HTTP) exposing 18 tools across read/write/admin scopes.

Distinct from existing memory entries: bitemporal (valid-time + transaction-time both modelled), conflict resolver with supersede/competing/revive semantics, three memory tiers (facts/episodes/procedural), GDPR-grade forget_entity. LoCoMo-benchmarked.

Repo: https://github.com/inite-ai/inite-brain-service
MCP Registry entry: io.github.inite-ai/inite-brain-service (in flight)