### PR TITLE
Add Vibe Creating — open-source bilingual text-to-video prompt skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) -  100+ specialized AI agents for full-stack development maintained by the community.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated list of Model Context Protocol (MCP) servers for extending Claude's capabilities.
 
+**Notable Community Skills**
+
+- [Vibe Creating](https://github.com/Alisa0808/vibe-creating-skill) -  Bilingual EN/中文 skill that rewrites a rough idea or over-specified shot script into a model-ready text-to-video prompt (Seedance 2.0, Kling, Veo, Hailuo, Wan, Vidu). Judgment-first; one SKILL.md; MIT.
+
 ---
 
 ## 🧩 Extensions & Integrations


### PR DESCRIPTION
Adds **Vibe Creating** to the ⭐ Community Curated Lists section, under a **Notable Community Skills** sub-grouping (matching the precedent set by the Forward Deployed Selling skill PR).

**Project:** https://github.com/Alisa0808/vibe-creating-skill

**What it is:** An open-source, bilingual (EN/中文) Claude Agent Skill (a single `SKILL.md`) that rewrites a rough idea or an over-stuffed shot script into a clean, model-ready text-to-video prompt. It is a faithful port of ByteDance's "Vibe Creating" paradigm (Seedance 2.0) and is judgment-first — it declines requests it cannot serve well (UI demos, tutorials, exact dialogue-sync). Works with Seedance 2.0, Kling, Veo, Hailuo, Wan, and Vidu. Install via `npx github:Alisa0808/vibe-creating-skill`. MIT licensed.

**Why it belongs here:** Open source with a public repo, MIT licensed, with clear install/usage documentation in the README — a community Claude Skill that fits the existing community-skill listings.

Format follows CONTRIBUTING: `- [Name](URL) -  Description.`, description starts with a capital and ends with a period, added at the bottom of the relevant category.

🤖 Generated with [Claude Code](https://claude.com/claude-code)