### PR TITLE
Add gh-image — upload images to GitHub from the CLI, with a Claude Code Agent Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
+- [gh-image](https://github.com/drogers0/gh-image#readme) -  `gh` CLI extension that uploads local images to GitHub and returns `user-attachments` URLs; ships an Agent Skill so Claude Code can attach screenshots to PRs, issues, and comments.
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
Adds [gh-image](https://github.com/drogers0/gh-image) to the **🤖 Claude Code** section.

`gh-image` is a `gh` CLI extension that uploads local images to GitHub and returns ready-to-embed `user-attachments` URLs. It ships a packaged **Agent Skill** (SKILL.md) so Claude Code can attach screenshots to PRs, issues, and comments directly from the terminal — GitHub has no public image-upload API, so this fills a real gap in Claude Code workflows.

- Open source (MIT), public repo, actively maintained, 102★.
- Install: `gh extension install drogers0/gh-image`.
- Ships `skills/github-image-upload/SKILL.md`.

One entry, matching the section's existing format.