### PR TITLE
Add Claude Usage Tracker to Applications > Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [Claude Usage Tracker](https://github.com/Liwindo/ClaudeUsageTracker#readme) -  Windows system-tray app that monitors your claude.ai session and weekly usage limits in real time from Firefox cookies — no API key needed. Free, MIT.
 
 ---
 


### PR DESCRIPTION
Adds [Claude Usage Tracker](https://github.com/Liwindo/ClaudeUsageTracker) to **💻 Applications → 🖥️ Desktop**.

It's an open-source (MIT) Windows system-tray app that shows your claude.ai **session (5-hour)** and **weekly** usage limits in real time — a colour-coded tray icon plus an optional floating widget. It reads your existing Firefox session cookies read-only, so there's **no API key, no login, and no stored credentials**. Ships as a single EXE (no Python needed) and has a CI-tested release pipeline.

- One entry added, alphabetically after "Claude Desktop Debian"
- Same `- [Name](url) -  Description.` format as the surrounding list
- Active project with tagged releases and a documented README