### PR TITLE
Add Claude Accounts to Desktop applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [Claude Accounts](https://deckspace.dev/claude-accounts/) - Run multiple Claude desktop accounts at once, each in its own isolated window (Mac & Windows, no Terminal); full source included.
 
 ---
 


### PR DESCRIPTION
Adds **Claude Accounts** to Applications → Desktop.

**What it is:** a small desktop utility that runs multiple Claude desktop accounts at the same time — each account in its own isolated data dir (`--user-data-dir` + separate `CLAUDE_CONFIG_DIR`), launched as a separate instance of the official Claude app, with detect-and-focus so a profile isn't duplicated/corrupted. Mac + Windows, no Terminal.

**Why include it:** there's strong demand for multi-account Claude (see anthropics/claude-code#20131) and no native support; this is the desktop-app, cross-platform answer. Full source is included in the download. Link: https://deckspace.dev/claude-accounts/

Format follows CONTRIBUTING (`- [Name](link) - Description.`), added to the bottom of the Desktop category.