### PR TITLE
Add Claude News (real-time Claude/Anthropic news + free MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [Claude News](https://claudenews.online) -  Real-time, Claude-curated Claude & Anthropic news with a free MCP server: add `https://claudenews.online/api/mcp` so your Claude can `search_news`/`recent_news` and answer with cited sources. No key.
 
 ---
 


### PR DESCRIPTION
Adds **Claude News** ([claudenews.online](https://claudenews.online)) to the **Model Context Protocol (MCP)** section.

Claude News is an independent, real-time news hub for Claude & Anthropic (models, Claude Code, research, safety), aggregated from the press, Hacker News, Reddit and GitHub and curated by Claude. It exposes a **free, no-key MCP server** (`https://claudenews.online/api/mcp`) with `search_news` and `recent_news` tools, so your own Claude can answer with cited sources. There's also a public JSON API and an RSS feed.

The entry follows the existing list format and sits next to the other MCP resources.

Disclosure: I'm involved with the project.