### PR TITLE
Add Metis

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 
+### ⌨️ Command Line
+
+- [Metis](https://github.com/chenlomis/metis) -  Claude-powered local CLI for job-search triage: ingests job alerts and company career pages, scores roles against a local profile, emails a ranked digest, and logs explainability traces.
+
 ---
 
 ## 📚 Educational Resources


### PR DESCRIPTION
Adds Metis, an open-source local CLI that uses Claude for job-search triage.\n\nMetis ingests job alerts and company career pages, scores roles against a local profile, emails a ranked digest, and stores local explainability traces for debugging.\n\nI placed it under Applications because it is a Claude-powered end-user CLI rather than a Claude Skill, prompt, or SDK.