### PR TITLE
Add Skill Hub — 5800+ AI Agent Skills Navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,3 +210,4 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 ---
 
 **[⬆ Back to Contents](#-contents)**
+- [Skill Hub](https://skill.442595.xyz/) — 5800+ curated AI Agent Skills for Claude Code, Codex, Cursor, Hermes & more across 22 categories.


### PR DESCRIPTION
Add [Skill Hub](https://skill.442595.xyz/) — a free directory of 5800+ curated AI agent skills for Claude Code, Codex, Cursor, Hermes, OpenClaw & more across 22 categories.