### PR TITLE
Add mailtrap/mailtrap-skills to Claude Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [hesreallyhim/awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code#readme) -  Slash-commands, CLAUDE.md files, CLI tools, and workflows for Claude Code.
 - [travisvn/awesome-claude-skills](https://github.com/travisvn/awesome-claude-skills#readme) -  Resources and tools for customizing AI workflows with Claude Skills.
+- [mailtrap/mailtrap-skills](https://github.com/mailtrap/mailtrap-skills) - Official Agent Skills for sending transactional and bulk emails via Mailtrap Email API and SMTP, including domain setup and contacts management.
 - [BehiSecc/awesome-claude-skills](https://github.com/BehiSecc/awesome-claude-skills#readme) -  Categorized skills for document handling, development tools, data analysis, and more.
 - [langgptai/awesome-claude-prompts](https://github.com/langgptai/awesome-claude-prompts#readme) -  Collection of prompt examples designed to improve Claude interactions.
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) -  Team of specialized AI agents for building features and debugging.


### PR DESCRIPTION
Adds mailtrap/mailtrap-skills, official Agent Skills from Mailtrap covering transactional email sending via Email API and SMTP, domain setup, and contacts management.