### PR TITLE
Add SeldonFrame MCP to Model Context Protocol section

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [SeldonFrame MCP](https://github.com/seldonframe/seldonframe) - Open-source MCP server to build, deploy, and sell AI agents for local-service businesses from your IDE. One command creates a live hosted workspace — website, booking, CRM, AI receptionist — in about 3 minutes.
 
 ---
 


### PR DESCRIPTION
Adds the SeldonFrame MCP server to the Model Context Protocol section. Open-source (AGPL-3.0) MCP server + Claude Code plugin: one command creates a live hosted business workspace — website, booking page, intake form, CRM, and an AI receptionist — in about 3 minutes, then the same server covers deploy, marketplace listing, and payouts. Listed on the official MCP registry as io.github.seldonframe/mcp; also on Smithery, Glama, and PulseMCP. First workspace is free with no API key.