### PR TITLE
Add ORION Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [ORION Protocol](https://github.com/mechana-ai/orion-protocol) - Runtime-first debugging protocol that breaks AI guesswork loops. Claude Code plugin (`/orion-protocol:orion`) and MCP debug ledger server, grounded in Baconian empirical method.
 
 ---
 


### PR DESCRIPTION
Adds [ORION Protocol](https://github.com/mechana-ai/orion-protocol) to the Claude Code & MCP section.

ORION Protocol is a runtime-first debugging framework that breaks AI guesswork loops. It ships as:
- A **Claude Code plugin** — activate with `/orion-protocol:orion` to force runtime investigation over code pattern-matching
- An **MCP debug ledger server** (`historia-naturalis`) for structured observation logging

Grounded in Francis Bacon's empirical method (1620), it uses epistemic shifting to reorient the LLM from passive code review into direct runtime probing.

https://github.com/mechana-ai/orion-protocol