### PR TITLE
Add Proliferate to desktop applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [Proliferate](https://proliferate.com/) -  Open-source local and cloud agent IDE for Claude Code with parallel workspaces, subagents, plugins, MCP, and review workflows.
 
 ---
 


### PR DESCRIPTION
Adds Proliferate to the Desktop applications section.

Why it fits:
- open-source local and cloud agent IDE
- supports Claude Code workflows directly
- includes parallel workspaces, subagents, plugins, MCP, and review flows

Source:
- https://github.com/proliferate-ai/proliferate
- https://proliferate.com/docs