### PR TITLE
Add claude-dual (dual Claude Desktop launcher for Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [claude-dual](https://github.com/WiredAndWrenched/claude-dual) - Run two independent Claude Desktop instances side by side on Windows, with hotkey and logon launch.
 
 ---
 


### PR DESCRIPTION
Adds [claude-dual](https://github.com/WiredAndWrenched/claude-dual), an MIT-licensed and actively maintained PowerShell launcher for running two independent Claude Desktop instances side by side on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)