### PR TITLE
Add DevIntern (ticket-to-PR automation for Claude Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### ⚙️ Workflow Automation
+
+- [DevIntern](https://github.com/getdevintern/devintern) -  Turns tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files into self-reviewed pull requests by driving Claude Code non-interactively. A feasibility gate flags vague tickets back to the tracker with questions; an optional unattended mode schedules ticket pickup and turns PR review comments into commits. Runs on your machines with your own Anthropic keys.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
## What

Adds [DevIntern](https://github.com/getdevintern/devintern) under a new **Workflow Automation** subsection in Extensions & Integrations.

## Why it should be included

DevIntern is a tool that picks up tickets from Jira, Linear, Trello, Asana, Azure DevOps, GitHub Issues, or markdown files and turns them into self-reviewed pull requests by driving Claude Code non-interactively (other coding agents are also supported). A feasibility gate flags vague tickets back to the tracker with questions, and an optional unattended mode schedules ticket pickup and turns PR review comments into commits. It runs on your own machines with your own Anthropic keys or subscription.

- Repo: https://github.com/getdevintern/devintern
- Docs: https://devintern.com/docs
- Site: https://devintern.com/

Note on licensing: the repo is public and actively maintained; the license is FSL-1.1 (source-available), free for interactive use. Happy to adjust placement or wording if you'd prefer.

Disclosure: I'm the author of DevIntern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)