### PR TITLE
Add Mastering Claude (The Claude Bible) to Community Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [40+ Claude Code Tips](https://github.com/ykdojo/claude-code-tips#readme) -  Tips for getting the most out of Claude Code, including a custom status line script, cutting the system prompt in half, using Gemini CLI as Claude Code's minion, and Claude Code running itself in a container. Also includes the dx plugin for GitHub Actions debugging, conversation cloning, and handoffs.
 - [My Experience With Claude Code After 2 Weeks of Adventures](https://sankalp.bearblog.dev/my-claude-code-experience-after-2-weeks-of-usage/) - Part 1: Real-world lessons on using a `TODO.md` file to keep Claude on track, managing costs, and why it often outperforms Cursor for complex refactors.
 - [A Guide to Claude Code 2.0 and getting better at using coding agents](https://sankalp.bearblog.dev/my-experience-with-claude-code-20-and-how-to-get-better-at-using-coding-agents/#setup) - Part 2: A deep dive into the 2.0 update, focusing on the "Agent Manager" mindset, context engineering, and using sub-agents for larger codebases.
+- [Mastering Claude (The Claude Bible)](https://mastering-claude.com/) - Free, no-signup interactive course of 237 lessons across 20 modules covering Claude.ai, Cowork, Claude Code, the API, prompt engineering, MCP, hooks, sub-agents, and multi-agent orchestration, with exercises, a final exam, a verifiable diploma, and a searchable directory of 500+ Claude Code skills. Available in English, French, and Spanish.
 
 ---
 


### PR DESCRIPTION
### Project
[Mastering Claude (The Claude Bible)](https://mastering-claude.com/)

### Section
Educational Resources > Community Guides

### What it is
A free, no-signup interactive course teaching Claude, Claude Code, Claude Cowork and the Claude API: 237 lessons across 20 modules, from beginner to expert, covering prompt engineering, MCP, hooks, sub-agents, context management, and multi-agent orchestration. Each lesson has an explanation, key takeaways, a demo, a guided exercise, and a quiz. It ends with a randomized final exam and a verifiable diploma, and it bundles a searchable directory of 500+ Claude Code skills.

### Why include it
It fits alongside the existing community guides (comprehensive, hands-on Claude Code learning). It is genuinely free with no account required, runs as a single self-contained page, and is one of the few resources available in English, French and Spanish. The entry follows the required format (`- [Name](link) - Description.`), one line, no emoji, factual.

Not affiliated with Anthropic; built and maintained independently.