### PR TITLE
Add Open Agent Relay to Claude Code resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
+- [Open Agent Relay](https://github.com/ShakespeareLabs/open-agent-relay) - Open-source, local-first CLI that lets Claude Code and other local agents expose bounded capabilities to teammates and agents over a trusted LAN while prompts, credentials, dependencies, and working directories stay on the publisher's machine.
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
## Summary

Add [Open Agent Relay](https://github.com/ShakespeareLabs/open-agent-relay) to the Claude Code section.

Open Agent Relay is an open-source, local-first CLI for exposing bounded Claude Code or other local-agent capabilities to teammates and agents over a trusted LAN. The publisher's prompts, credentials, dependencies, and working directory remain local.

## Fit and disclosure

I maintain the submitted project. It has direct Claude Code usage documented, is actively maintained, and provides functionality beyond an example. The project is currently Alpha and uses HTTP with a shared key for trusted-LAN use; this entry does not claim MCP support or production-grade public deployment.