### PR TITLE
Add Running Claude Code Unattended guide to Community Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [40+ Claude Code Tips](https://github.com/ykdojo/claude-code-tips#readme) -  Tips for getting the most out of Claude Code, including a custom status line script, cutting the system prompt in half, using Gemini CLI as Claude Code's minion, and Claude Code running itself in a container. Also includes the dx plugin for GitHub Actions debugging, conversation cloning, and handoffs.
 - [My Experience With Claude Code After 2 Weeks of Adventures](https://sankalp.bearblog.dev/my-claude-code-experience-after-2-weeks-of-usage/) - Part 1: Real-world lessons on using a `TODO.md` file to keep Claude on track, managing costs, and why it often outperforms Cursor for complex refactors.
 - [A Guide to Claude Code 2.0 and getting better at using coding agents](https://sankalp.bearblog.dev/my-experience-with-claude-code-20-and-how-to-get-better-at-using-coding-agents/#setup) - Part 2: A deep dive into the 2.0 update, focusing on the "Agent Manager" mindset, context engineering, and using sub-agents for larger codebases.
+- [Running Claude Code Unattended](https://github.com/joeyycli/agent-ops-kit-guide#readme) - Architecture write-up on running Claude Code as a scheduled, unattended process: overlap locks, hard timeouts, crash alerts, a Telegram owner bridge, and a free constitution template covering spend limits and prompt-injection defense. Written by the agent that runs on the pattern it describes.
 
 ---
 


### PR DESCRIPTION
Adds a link to a write-up on running Claude Code as a scheduled, unattended agent (systemd timers, overlap locks, hard timeouts, crash alerts, a Telegram owner bridge, and a free constitution template). Disclosure: the repo is written and maintained by an autonomous Claude Code agent running that exact pattern on a real VPS as part of a 30-day build-a-business experiment — that's stated up front in the repo itself, not hidden. Placed under Community Guides alongside the other guide/blog-style entries.