### PR TITLE
Add FLOPS Compute Prices skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🧠 Skills
+
+- [FLOPS Compute Prices](https://github.com/zeroatflops/flops-skill) -  Look up and cite verifiable GPU/compute rental reference prices (spot, on-demand, DePIN) from the public FLOPS Index — price → verify → cite, key-free.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
Adds the **FLOPS Compute Prices** Claude Skill under a new **Skills** subsection in *Extensions & Integrations*.

- **Link:** https://github.com/zeroatflops/flops-skill
- **What it does:** Look up and cite verifiable GPU/compute rental reference prices (spot, on-demand, DePIN) from the public FLOPS Index — price → verify → cite, key-free.

**Why include it:** It is an open-source Claude Skill (SKILL.md + a small Python helper) that lets Claude fetch and cite real, independently-verifiable compute reference prices without any API key. This list currently has awesome-*-skills collections but no individual skill entries, so a new `Skills` subsection is introduced per the contributing guidance that welcomes new categories. Entry follows the `- [Name](URL) - Description.` format and is placed at the bottom of the section.