### PR TITLE
Add Agent Skills section with HyperShots

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
 
+### 🧰 Agent Skills
+
+Installable skills that teach Claude Code (and other coding agents) specialized workflows.
+
+- [Anthropic Skills](https://github.com/anthropics/skills#readme) -  Official example skills from Anthropic covering documents, data, and creative tasks.
+- [HyperShots](https://github.com/hypersocialinc/hypershots#readme) -  Generates App Store screenshots as HTML rendered at exact store dimensions, with a spec validator, one-command localization, and fastlane submission.
+
 ### 🔌 Model Context Protocol (MCP)
 
 Open standard (Linux Foundation) for connecting Claude to tools, repos, databases, tickets, and more. Supports one-click desktop extensions (`.mcpb` files).


### PR DESCRIPTION
## Why

The list covers Claude Code, MCP, extensions, and curated lists, but has no place for individual installable agent skills — a fast-growing category since skills launched. This PR adds a small **Agent Skills** subsection under the Claude Code & MCP section, seeded with Anthropic's official skills repo and one community skill.

**[HyperShots](https://github.com/hypersocialinc/hypershots)** (MIT) generates App Store screenshots from a coding agent: panels authored as HTML, rendered by headless Chrome at exact store dimensions, checked by a fail-closed validator for everything App Store Connect rejects (dimensions, alpha, ICC profile, panel count, 8 MB cap), plus one-command localization and a fastlane submission runbook. Actively maintained, 17-test CI suite, documentation at [hypershots.dev](https://hypershots.dev). Disclosure: I'm the author of HyperShots.

Format follows contributing.md (individual PR, `- [Name](URL) - Description.`, added alphabetically).