### PR TITLE
Add VirtualSMS MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [VirtualSMS MCP](https://github.com/virtualsms-io/mcp-server) -  MCP server for SMS and OTP account verification, number rentals, and proxies across 145+ countries.
 
 ---
 


### PR DESCRIPTION
Adds the VirtualSMS MCP server (open source, MIT) to the MCP section.

- Repo: https://github.com/virtualsms-io/mcp-server
- What it is: an MCP server exposing 40 tools for SMS/OTP account verification, number rentals, and proxies across 145+ countries — usable directly via MCP.
- Actively maintained, documented install/usage in the README.

Happy to move it to a more appropriate spot if the MCP section is reserved for official resources.

— The VirtualSMS Team