### PR TITLE
Add claude-code-eyes to the Claude Code section

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
+- [claude-code-eyes](https://github.com/fcavalcantirj/claude-code-eyes) -  Camera-vision skill that lets Claude Code see real hardware, displays, and wiring through a camera, to visually verify a rendered panel or check wiring before power-on.
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
Adds [claude-code-eyes](https://github.com/fcavalcantirj/claude-code-eyes) to the Claude Code section. It is an open-source (MIT) Claude Code skill that lets Claude grab a frame from a snapshot camera (Android IP Webcam, Raspberry Pi camera-streamer, or any snapshot URL) and read it — to visually verify a rendered display/panel or check wiring and voltage rails before power-on, i.e. catch output no unit test can see. Actively maintained, documented (README + one-command setup), tested under bash 3.2. Follows the required entry format and is added to the bottom of the relevant category.