### PR TITLE
Add RAG-OS to Community Guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [40+ Claude Code Tips](https://github.com/ykdojo/claude-code-tips#readme) -  Tips for getting the most out of Claude Code, including a custom status line script, cutting the system prompt in half, using Gemini CLI as Claude Code's minion, and Claude Code running itself in a container. Also includes the dx plugin for GitHub Actions debugging, conversation cloning, and handoffs.
 - [My Experience With Claude Code After 2 Weeks of Adventures](https://sankalp.bearblog.dev/my-claude-code-experience-after-2-weeks-of-usage/) - Part 1: Real-world lessons on using a `TODO.md` file to keep Claude on track, managing costs, and why it often outperforms Cursor for complex refactors.
 - [A Guide to Claude Code 2.0 and getting better at using coding agents](https://sankalp.bearblog.dev/my-experience-with-claude-code-20-and-how-to-get-better-at-using-coding-agents/#setup) - Part 2: A deep dive into the 2.0 update, focusing on the "Agent Manager" mindset, context engineering, and using sub-agents for larger codebases.
+- [RAG-OS](https://github.com/csnyder256/RAG-OS#readme) - A vendor-neutral blueprint you paste into Claude Code (or another coding agent) to build a self-hosted, always-on personal AI OS, covering the kernel, worker dispatch, a git-Markdown knowledge base, hybrid retrieval, budget, and security, with a runnable starter scaffold.
 
 ---
 


### PR DESCRIPTION
Adds [RAG-OS](https://github.com/csnyder256/RAG-OS) to Educational Resources -> Community Guides.

RAG-OS is a vendor-neutral, MIT-licensed build guide for a self-hosted, always-on personal AI OS: an agent that dispatches coding tasks across repos and maintains a git-Markdown knowledge base. It is written to be pasted into Claude Code (or another coding agent), which then builds the system with the user, and it ships a runnable stdlib-only starter scaffold. It fits alongside the existing Community Guides entries.

- Uses the format `- [Name](URL) - Description.`
- Added to the bottom of the Community Guides category
- Single suggestion in this PR