### PR TITLE
Add Cowork-to-Code Bridge (Desktop integrations)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [Cowork-to-Code Bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge#readme) -  Local-first async bridge connecting Claude Cowork (and any MCP-aware agent) to Claude Code on your own machine. Queue tasks from a sandboxed session; a local daemon runs them on real hardware with per-task model, budget, and permission ceilings.
 
 ---
 


### PR DESCRIPTION
Adds [Cowork-to-Code Bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge) under **Extensions & Integrations → Desktop**.

It's a local-first, MIT-licensed async bridge that connects Claude Cowork (and any MCP-aware agent — CrewAI, AutoGen, LlamaIndex, …) to Claude Code running on the user's own Mac/Linux machine: queue a task from a sandboxed session, a local daemon executes it on real hardware, results stream back with per-task model/budget/permission ceilings.

Entry follows the existing format (link + one-line description). Thanks for the great list!