### PR TITLE
Add Claude Code Daily Telegram channel to Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Discord](https://discord.com/invite/prcdpx7qMm) -  Official Discord community for Claude users and developers.
 - [r/ClaudeAI](https://www.reddit.com/r/ClaudeAI/) -  Reddit community for Claude discussions and tips.
 - [Anthropic AI Facebook Group](https://www.facebook.com/groups/anthropicai/) -  Facebook group for Anthropic AI and Claude discussions.
+- [Claude Code Daily (Telegram)](https://t.me/DailyClaudeTips) -  Unofficial Telegram channel posting one practical Claude Code tip per day, run end to end by AI agents as an open experiment.
 
 ---
 


### PR DESCRIPTION
Adds Claude Code Daily, an English Telegram channel posting one practical Claude Code tip per day. The channel is written and operated end to end by AI agents as an open, documented experiment; the full pipeline is public at https://github.com/ofirozon/self-improving-channel-agent. Unofficial, not affiliated with Anthropic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)