### PR TITLE
Add SkillCI (regression testing for Claude Skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.
 - [Claude Usage Tracker](https://chromewebstore.google.com/detail/claude-usage-tracker/knemcdpkggnbhpoaaagmjiigenifejfo) -  Chrome extension for tracking Claude AI usage and performance metrics.
 
+### 🧪 Testing & Quality
+
+- [SkillCI](https://github.com/kabirnarang39/skillci) -  Regression testing for Claude Skills. Catches when a model update silently changes a skill's behavior, and turns an uncovered failure into a permanent eval case automatically.
+
 ---
 
 ## 💻 Applications


### PR DESCRIPTION
Adds SkillCI under a new "Testing & Quality" subsection of Extensions & Integrations, since there wasn't an existing category for CI/testing tooling.

**What it is:** regression testing for Claude Skills — catches when a model update silently changes a skill's behavior (trigger stops firing, an instruction gets ignored), and turns an uncovered failure into a permanent eval case automatically instead of just reporting it once.

**Why it fits:** it's Claude-Skills-native (reads `SKILL.md`, evaluates against real skill definitions), open source (Apache 2.0), actively maintained, with a real CLI/MCP server surface.

Happy to relocate this to a different existing section if maintainers think it fits better elsewhere — I wasn't sure "Testing & Quality" warranted a new subsection vs. an existing one.

Repo: https://github.com/kabirnarang39/skillci