### PR TITLE
feat: add DigestSEO GEO Tracker to MCP resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [DigestSEO GEO Tracker](https://github.com/AKzar1el/mcp-geo) - MCP server for measuring brand citations and AI-search visibility across ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews.
 
 ---
 


### PR DESCRIPTION
## What this adds

Adds DigestSEO GEO Tracker to the MCP section.

DigestSEO GEO Tracker measures brand citations and visibility across ChatGPT, Claude, Perplexity, Gemini, and Google AI Overviews, with history, competitor comparison, citation evidence, and content-gap analysis.

Source: https://github.com/AKzar1el/mcp-geo
Hosted endpoint: https://geo-mcp.digestseo.com/mcp
Local install: `npx -y digestseo-mcp`

The project is public, actively maintained, documented, and already provides a working MCP server and npm distribution. The entry follows this repository's requested format and adds one line only.