### PR TITLE
Add Power Claude under IDE Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Claude Code Theme](https://github.com/ashwingopalsamy/claude-code-theme) -  Claude-inspired VS Code theme pack with dark/light/high-contrast and brand variants, semantic token tuning, and ANSI-optimized terminal colors.
 - [Claude VSCode Theme](https://marketplace.visualstudio.com/items?itemName=AlvinUnreal.claude-vscode-theme) -  Thoughtful dark theme collection with classic and italic variants. Inspired by Claude AI with carefully balanced contrast and warm syntax colors.
 
+- [Power Claude](https://marketplace.visualstudio.com/items?itemName=neural-llm.power-claude) -  Local VS Code/Cursor extension + CLI for multi-seat Claude Code orchestration, session recovery, Token Saver, and local cost analytics. Independent third-party software.
+
 ### 🌐 Browser Extensions
 
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Max plan required. Claude works directly in your browser and takes actions on your behalf. Features scheduled tasks, planning mode, multi-tab workflows, and smart navigation for Slack, Gmail, Google Calendar, Docs, and GitHub.


### PR DESCRIPTION
## Summary
Adds Power Claude to **Extensions & Integrations → IDE Extensions**.

Local VS Code/Cursor extension for multi-seat Claude Code orchestration, session recovery, Token Saver, and local cost analytics. Independent third-party (not affiliated with Anthropic).

- Marketplace: https://marketplace.visualstudio.com/items?itemName=neural-llm.power-claude
- Open VSX: https://open-vsx.org/extension/neural-llm/power-claude
- Site: https://neural-llm.com/power-claude