### PR TITLE
Add superviewer under Applications > Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 ### 🖥️ Desktop
 
+- [superviewer](https://github.com/dodlabinc/superviewer-releases) -  Desktop viewer for AI agent (Claude Code) generated artifacts — images, HTML, video, markdown, docs. One MCP tool call renders content instantly, no browser needed. macOS.
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
 


### PR DESCRIPTION
Adds superviewer, a Tauri-based desktop viewer for Claude Code / AI agent-generated artifacts (images, HTML, video, markdown, documents), to Applications > Desktop.

- One MCP tool call renders content instantly in a persistent desktop window — no browser needed.
- macOS, MCP-compatible.
- Download/releases: https://github.com/dodlabinc/superviewer-releases