### PR TITLE
Add AGINE Academy (game-based Claude learning) to Educational Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [40+ Claude Code Tips](https://github.com/ykdojo/claude-code-tips#readme) -  Tips for getting the most out of Claude Code, including a custom status line script, cutting the system prompt in half, using Gemini CLI as Claude Code's minion, and Claude Code running itself in a container. Also includes the dx plugin for GitHub Actions debugging, conversation cloning, and handoffs.
 - [My Experience With Claude Code After 2 Weeks of Adventures](https://sankalp.bearblog.dev/my-claude-code-experience-after-2-weeks-of-usage/) - Part 1: Real-world lessons on using a `TODO.md` file to keep Claude on track, managing costs, and why it often outperforms Cursor for complex refactors.
 - [A Guide to Claude Code 2.0 and getting better at using coding agents](https://sankalp.bearblog.dev/my-experience-with-claude-code-20-and-how-to-get-better-at-using-coding-agents/#setup) - Part 2: A deep dive into the 2.0 update, focusing on the "Agent Manager" mindset, context engineering, and using sub-agents for larger codebases.
+- [AGINE Academy](https://academy.agineai.com/en) - Game-based academy for learning Claude by real practice: missions run inside the real Claude apps, from setup to Projects, skills and Claude Code. The 4-lesson starting block is free with no sign-up. Independent, not affiliated with Anthropic.
 
 ---
 


### PR DESCRIPTION
Adds AGINE Academy to Community Guides.

Disclosure: I help build this product. It is a game-based academy for learning Claude through hands-on missions that run inside the real Claude apps (from setup to Projects, skills and Claude Code). The 4-lesson starting block is free and needs no sign-up; the full program is paid. Available in English and Russian. Independent product, not affiliated with Anthropic.

Happy to adjust wording or placement if it fits better elsewhere.