### PR TITLE
Add gh-attach to Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
+- [gh-attach](https://github.com/sudosubin/gh-attach#readme) -  GitHub CLI (`gh`) extension that uploads and downloads user-attachments (screenshots, PDFs, zips, videos) and returns `user-attachments` URLs; ships an Agent Skill so Claude Code can attach files to PRs, issues, and comments.
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
Adds [gh-attach](https://github.com/sudosubin/gh-attach) to the **🤖 Claude Code** section.

`gh-attach` is a `gh` CLI extension (and packaged Agent Skill) that uploads and downloads GitHub user-attachments and returns `user-attachments` URLs. GitHub has no public API for these attachments, so it fills a real gap for attaching and fetching files on PRs, issues, and comments from Claude Code (MIT, `gh extension install sudosubin/gh-attach`).

One entry, added to the bottom of the section and matching the existing format.
