### PR TITLE
Add awesome-seedance-2.5-prompts-skills to Community Curated Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [vijaythecoder/awesome-claude-agents](https://github.com/vijaythecoder/awesome-claude-agents#readme) -  Team of specialized AI agents for building features and debugging.
 - [VoltAgent/awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents#readme) -  100+ specialized AI agents for full-stack development maintained by the community.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated list of Model Context Protocol (MCP) servers for extending Claude's capabilities.
+- [AtlasCloudAI/awesome-seedance-2.5-prompts-skills](https://github.com/AtlasCloudAI/awesome-seedance-2.5-prompts-skills#readme) -  150+ Seedance 2.5 video prompts bundled with an installable skill for prompt refinement, storyboard planning, and video generation.
 
 ---
 


### PR DESCRIPTION
Adds one entry to **⭐ Community Curated Lists**.

[AtlasCloudAI/awesome-seedance-2.5-prompts-skills](https://github.com/AtlasCloudAI/awesome-seedance-2.5-prompts-skills) is a curated list of 150+ Seedance 2.5 video prompts (categorised by camera move, lighting, material, multi-character dialogue), bundled with an installable Agent Skill that refines a prompt, plans a storyboard when the shot needs one, and generates the video. 115 stars, CC BY 4.0, README in 19 languages, v1.0.0 tagged.

It belongs in this section rather than a skills section because the repo is itself a community-curated list — same shape as the langgptai/awesome-claude-prompts and BehiSecc entries already here.

Disclosure: I work at Atlas Cloud, whose API the bundled skill calls by default; the prompt list itself is platform-agnostic.