### PR TITLE
Add Tintpad under Applications > Desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 
 - [Claude Desktop](https://claude.ai/download) -  Official Claude desktop app for macOS and Windows. Includes a dedicated **Code** tab (GUI for Claude Code) and **Cowork** for non-technical users.
 - [Claude Desktop Debian](https://github.com/aaddrick/claude-desktop-debian#readme) -  Unofficial Claude desktop app for Debian/Linux.
+- [Tintpad](https://github.com/sorkila/tintpad) -  Open-source macOS menu-bar launcher that opens your terminal at any repo with Claude Code (or another coding agent) running. Global hotkey, fuzzy repo search, frecency ranking.
 
 ---
 


### PR DESCRIPTION
Adds [Tintpad](https://github.com/sorkila/tintpad), a free, open-source (MIT) native macOS menu-bar launcher: a global hotkey opens a palette, fuzzy-find a git repo (frecency-ranked), pick Claude Code (or Codex, Gemini CLI) and a run mode, and your own terminal opens at that repo with the agent already running. Local-only, no accounts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)