### PR TITLE
Add Floe Agent Skills under Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
+- [Floe Agent Skills](https://github.com/Floe-Labs/agent-skills) -  Agent skill giving Claude Code metered, budget-capped multi-vendor API access (LLM, STT, TTS, telephony, search, data) through one key, with per-call cost attribution and spend limits.
 
 ### 🔌 Model Context Protocol (MCP)
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Terminal-first agentic coding tool (CLI), with VS Code/JetBrains IDE integration
 - [Claude Desktop](https://claude.ai/download) -  macOS + Windows app; includes **Cowork** GUI for non-technical workflows and the dedicated **Code** tab.
 - Install CLI: `curl -fsSL https://claude.ai/install.sh | bash` (macOS/Linux) or via Homebrew/Winget.
 - [Claude for Chrome (Beta)](https://chromewebstore.google.com/detail/claude/fcoeoabgfenejglbffodgkkbkcdhcgfn) -  Integrates with Claude Code for browser control (multi-tab workflows, Slack, Gmail, GitHub).
-- [Floe Agent Skills](https://github.com/Floe-Labs/agent-skills) -  Agent skill giving Claude Code metered, budget-capped multi-vendor API access (LLM, STT, TTS, telephony, search, data) through one key, with per-call cost attribution and spend limits.
+- [Floe Agent Skills](https://github.com/Floe-Labs/agent-skills) -  An agent skill giving Claude Code metered, budget-capped multi-vendor API access (LLM, STT, TTS, telephony, search, data) through one key, with per-call cost attribution and spend limits.
 
 ### 🔌 Model Context Protocol (MCP)
 


### PR DESCRIPTION
Adds [Floe Agent Skills](https://github.com/Floe-Labs/agent-skills) to the bottom of the **Claude Code** section.

**Why include it:** open-source (MIT), actively maintained Claude Skill that gives Claude Code metered, budget-capped access to LLM, STT, TTS, telephony, search, and data APIs through one key — with per-call cost attribution and spend limits enforced before each call. Works with Claude Code, the Claude Agent SDK, and Cursor.

There is no dedicated Skills section, so I placed it under Claude Code as the closest fit — happy to move it if you'd prefer a new subsection. Entry format follows the existing `- [Name](link) -  Description.` style.