### PR TITLE
Add Hexis to the MCP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Open standard (Linux Foundation) for connecting Claude to tools, repos, database
 - [Introduction to MCP](https://anthropic.skilljar.com/introduction-to-model-context-protocol) -  Official Anthropic course: build MCP servers and clients from scratch in Python.
 - [MCP: Advanced Topics](https://anthropic.skilljar.com/model-context-protocol-advanced-topics) -  Sampling, notifications, transports.
 - [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers#readme) -  Curated community list of MCP servers.
+- [Hexis](https://github.com/Bevel-Software/Hexis) - Git-backed platform for skills, tools, and context for AI agents, with a remote MCP server that works with Claude.
 
 ---
 


### PR DESCRIPTION
Adds Hexis to the Model Context Protocol section. Hexis is an open-source, Git-backed platform for skills, tools, and context for AI agents, and its remote MCP server works with Claude.